### PR TITLE
Use the correct syntax for the build workflow.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: ${{ github.base_ref == 'main' && github.event.pull_request.merged == true && !contains(github.event.pull_request.labels._.name, 'Version bump') }}
+    if: ${{ github.base_ref == 'main' && github.event.pull_request.merged == true && !contains(github.event.pull_request.labels.*.name, 'Version bump') }}
     steps:
       - uses: actions/checkout@v3
       - run: gh workflow run deploy.yml


### PR DESCRIPTION
For some reason, this has an underscore which doesn't work so we're
getting stuck in an infinite loop where the version bump merge starts
another release.

This should work
