### PR TITLE
DR2-1123 Add httpClient to dynamo client

### DIFF
--- a/dynamodb/src/main/scala/uk/gov/nationalarchives/DADynamoDBClient.scala
+++ b/dynamodb/src/main/scala/uk/gov/nationalarchives/DADynamoDBClient.scala
@@ -3,6 +3,8 @@ package uk.gov.nationalarchives
 import cats.effect.Async
 import cats.implicits._
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import software.amazon.awssdk.services.dynamodb.model._
@@ -82,8 +84,10 @@ class DADynamoDBClient[F[_]: Async](dynamoDBClient: DynamoDbAsyncClient) {
   }
 }
 object DADynamoDBClient {
+  private val httpClient: SdkAsyncHttpClient = NettyNioAsyncHttpClient.builder().build()
   private val dynamoDBClient: DynamoDbAsyncClient = DynamoDbAsyncClient
     .builder()
+    .httpClient(httpClient)
     .region(Region.EU_WEST_2)
     .credentialsProvider(DefaultCredentialsProvider.create())
     .build()


### PR DESCRIPTION
As it is, it works locally but not running in the lambda. I don't know
why but if you add the client in, it works.
