### PR TITLE
Add head object method

### DIFF
--- a/s3/src/main/scala/uk/gov/nationalarchives/DAS3Client.scala
+++ b/s3/src/main/scala/uk/gov/nationalarchives/DAS3Client.scala
@@ -13,7 +13,6 @@ import software.amazon.awssdk.transfer.s3.model._
 
 import java.nio.ByteBuffer
 import java.util.concurrent.CompletableFuture
-import scala.util.Try
 
 /** An S3 client. It is written generically so can be used for any effect which has an Async instance. Requires an
   * implicit instance of cats Async which is used to convert CompletableFuture to F
@@ -115,8 +114,6 @@ class DAS3Client[F[_]: Async](transferManager: S3TransferManager, asyncClient: S
       .bucket(bucket)
       .key(key)
       .build
-    val d = Try(asyncClient.headObject(headObjectRequest).get())
-    print(d)
     asyncClient.headObject(headObjectRequest).liftF
   }
 

--- a/site-docs/src/main/paradox/s3/usage/fs2.md
+++ b/site-docs/src/main/paradox/s3/usage/fs2.md
@@ -13,7 +13,7 @@ group2="co.fs2" artifact2="fs2-reactive-streams_2.13" version2="3.7.0"
 import cats.effect._
 import fs2.Stream
 import fs2.interop.reactivestreams._
-import software.amazon.awssdk.transfer.s3.model.CompletedUpload
+import software.amazon.awssdk.transfer.s3.model._
 import uk.gov.nationalarchives.DAS3Client
 
 val fs2Client = DAS3Client[IO, Stream[IO, Byte]]()
@@ -27,5 +27,13 @@ def upload(s: Stream[IO, Byte], fileSize: Long): IO[CompletedUpload] = {
 def download(bucket: String, key: String): IO[Stream[IO, Byte]] = {
   fs2Client.download(bucket, key)
     .map(_.toStreamBuffered[IO](1024 * 1024).map(_.get()))
+}
+
+def copy(sourceBucket: String, sourceKey: String, destinationBucket: String, destinationKey: String): IO[CompletedCopy] = {
+  fs2Client.copy(sourceBucket, sourceKey, destinationBucket, destinationKey)
+}
+
+def headObject(bucket: String, key: String): IO[HeadObjectResponse] = {
+  fs2Client.headObject(bucket, key)
 }
 ```

--- a/site-docs/src/main/paradox/s3/usage/index.md
+++ b/site-docs/src/main/paradox/s3/usage/index.md
@@ -9,19 +9,23 @@ val clientWithCustom = new DAS3Client(customTransferManager)
 val clientWithDefault = DAS3Client()
 ```
 
-The client exposes two methods:
+The client exposes four methods:
 
 ```scala
 def upload(bucket: String, key: String, contentLength: Long, publisher: Publisher[ByteBuffer]): F[CompletedUpload]
 
 def download(bucket: String, key: String): F[Publisher[ByteBuffer]]
+
+def copy(sourceBucket: String, sourceKey: String, destinationBucket: String, destinationKey: String ): F[CompletedCopy]
+
+def headObject(bucket: String, key: String): F[HeadObjectResponse]
 ```
 
-Both methods stream the data using the Java Reactive streams standard. 
+The upload and download methods stream the data using the Java Reactive streams standard. 
 It is possible to work directly with the `Publisher` objects, but it should be easier to wrap them in a streaming library. 
 There are examples for both Zio and Fs2.
 
-The method takes a content length because it's not currently possible to send a stream of arbitrary length to S3.
+The upload method takes a content length because it's not currently possible to send a stream of arbitrary length to S3.
 There is an [open GitHub issue](https://github.com/aws/aws-sdk-java-v2/issues/139) with [associated pull request](https://github.com/awslabs/aws-c-s3/pull/285)
 which should fix this soon but until then, we need to pass this in.
 

--- a/site-docs/src/main/paradox/s3/usage/zio.md
+++ b/site-docs/src/main/paradox/s3/usage/zio.md
@@ -17,7 +17,7 @@ group3="dev.zio" artifact3="zio-interop-cats_2.13" version3="23.0.0.5"
 ```scala
 import zio.stream.Stream
 import zio._
-import software.amazon.awssdk.transfer.s3.model.CompletedUpload
+import software.amazon.awssdk.transfer.s3.model._
 import java.nio.ByteBuffer
 import zio.interop.reactivestreams._
 import zio.interop.catz._
@@ -32,6 +32,14 @@ def upload(stream: Stream[Throwable, Byte], contentLength: Long): Task[Completed
 def download(bucket: String, key: String) = {
   s3Client.download(bucket, key)
     .map(_.toZIOStream().map(_.get())) //Publisher[ByteBuffer] to Stream[ThrowableByte]
+}
+
+def copy(sourceBucket: String, sourceKey: String, destinationBucket: String, destinationKey: String): Task[CompletedCopy] = {
+  s3Client.copy(sourceBucket, sourceKey, destinationBucket, destinationKey)
+}
+
+def headObject(bucket: String, key: String): Task[HeadObjectResponse] = {
+  s3Client.headObject(bucket, key)
 }
 
 ```


### PR DESCRIPTION
I've added the headObject method as we'll need it for the opex folder
creator lambda to get the file size of the existing opex xml from S3.
