### PR TITLE
Remove scaladoc generation.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -139,10 +139,8 @@ lazy val docs = (project in file("site-docs"))
     description := "Markdown files which are published as GitHub pages documentation",
     publish / skip := true
   )
-  .enablePlugins(ParadoxSitePlugin, ScalaUnidocPlugin, SitePreviewPlugin)
+  .enablePlugins(ParadoxSitePlugin, SitePreviewPlugin)
   .settings(
     paradoxProperties += ("version" -> (ThisBuild / version).value.split("-").head),
-    paradoxTheme := Some(builtinParadoxTheme("generic")),
-    ScalaUnidoc / siteSubdirName := "api",
-    addMappingsToSiteDir(ScalaUnidoc / packageDoc / mappings, ScalaUnidoc / siteSubdirName)
+    paradoxTheme := Some(builtinParadoxTheme("generic"))
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,4 +4,3 @@ resolvers += Resolver.jcenterRepo
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.10.0")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
 addSbtPlugin("com.github.sbt" % "sbt-site-paradox" % "1.6.0")
-addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")

--- a/site-docs/src/main/paradox/index.md
+++ b/site-docs/src/main/paradox/index.md
@@ -4,8 +4,6 @@ A set of AWS clients which provide methods useful across Digital Archiving.
 The methods are written using generic types with the Cats type classes. 
 This allows any calling code to use any effects which implement these classes, most commonly ZIO or Cats Effect.
 
-View the [Scaladoc](api/uk/gov/nationalarchives/index.html) 
-
 @@@ index
 
 * [DynamoDB Client Usage](dynamodb/usage/index.md)


### PR DESCRIPTION
The unidoc plugin isn't working with Scala 3. There's probably a way to
do this but it's not a huge priority so I'll remove it for now.

The main documentation is still there, it's just the scaladoc that's
missing.
