### PR TITLE
Add writeItem in order to use conditional expressions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: DP Run Tests
 on:
-  pull_request:
+  push:
 jobs:
   test:
     runs-on:  ubuntu-latest

--- a/site-docs/src/main/paradox/dynamodb/usage/fs2.md
+++ b/site-docs/src/main/paradox/dynamodb/usage/fs2.md
@@ -38,6 +38,20 @@ def getItemsExample(tableName: String, partitionKeyValue1: String, partitionKeyV
   fs2Client.getItems[GetItemsResponse, PartitionKey](partitionKeys, tableName)
 }
 
+def writeItemExample(tableName: String, attributeName: String, attributeName2: String, newAttributeValue: String,
+                     newAttributeValue2: String): IO[Int] = {
+
+  val dynamoDbWriteItemRequest = DADynamoDbWriteItemRequest(
+    tableName,
+    Map(
+      attributeName -> Some(AttributeValue.builder().s(newAttributeValue).build()),
+      attributeName2 -> Some(AttributeValue.builder().s(newAttributeValue2).build())
+    )
+    Some("attribute_not_exists(attributeName)")
+  )
+  fs2Client.writeItem(dynamoDbWriteItemRequest)
+}
+
 def writeItemsExample(tableName: String): IO[BatchWriteItemResponse] = {
   val WriteItemsRequest = List(WriteItemsRequest("attributeValue", WriteItemsNestedRequest("attributeValue2")))
   fs2Client.writeItems(tableName, WriteItemsRequest)

--- a/site-docs/src/main/paradox/dynamodb/usage/zio.md
+++ b/site-docs/src/main/paradox/dynamodb/usage/zio.md
@@ -43,6 +43,21 @@ def getItemsExample(tableName: String, partitionKeyValue1: String, partitionKeyV
   val partitionKeys = List(partitionKey1, partitionKey2)
   zioClient.getItems[GetItemsResponse, PartitionKey](partitionKeys, tableName)
 }
+
+def writeItemExample(tableName: String, attributeName: String, attributeName2: String, newAttributeValue: String,
+                     newAttributeValue2: String): IO[Int] = {
+
+  val dynamoDbWriteItemRequest = DADynamoDbWriteItemRequest(
+    tableName,
+    Map(
+      attributeName -> Some(AttributeValue.builder().s(newAttributeValue).build()),
+      attributeName2 -> Some(AttributeValue.builder().s(newAttributeValue2).build())
+    )
+      Some("attribute_not_exists(attributeName)")
+  )
+  zioClient.writeItem(dynamoDbWriteItemRequest)
+}
+
 def writeItemsExample(tableName: String): Task[BatchWriteItemResponse] = {
   val writeItemsRequest = List(WriteItemsRequest("attributeValue", WriteItemsNestedRequest("attributeValue2")))
   zioClient.writeItems(tableName, writeItemsRequest)


### PR DESCRIPTION
For some reason, AWS do not allow you to add conditional expressions on BatchWriteItem requests as they take PutRequest, but putItem requests take PutItemRequest which allow conditional expressions; the only disadvanage is that they take one item per request.