### PR TITLE
Allow for empty unprocessed items map.

### DIFF
--- a/dynamodb/src/main/scala/uk/gov/nationalarchives/DADynamoDBClient.scala
+++ b/dynamodb/src/main/scala/uk/gov/nationalarchives/DADynamoDBClient.scala
@@ -85,7 +85,8 @@ class DADynamoDBClient[F[_]: Async](dynamoDBClient: DynamoDbAsyncClient):
         Async[F].tailRecM(valuesToWrite) { reqs =>
           val req = BatchWriteItemRequest.builder().requestItems(Map(tableName -> reqs.asJava).asJava).build()
           dynamoDBClient.batchWriteItem(req).liftF.map {
-            case resUnprocessed if resUnprocessed.hasUnprocessedItems =>
+            case resUnprocessed
+                if resUnprocessed.hasUnprocessedItems && resUnprocessed.unprocessedItems.containsKey(tableName) =>
               Left(resUnprocessed.unprocessedItems.get(tableName).asScala.toList)
             case res => Right(res)
           }

--- a/dynamodb/src/test/scala/uk/gov/nationalarchives/DADynamoDBClientTest.scala
+++ b/dynamodb/src/test/scala/uk/gov/nationalarchives/DADynamoDBClientTest.scala
@@ -323,6 +323,7 @@ class DADynamoDBClientTest
         .statusCode(200)
         .build()
       val writeItemResponse = BatchWriteItemResponse.builder
+        .unprocessedItems(java.util.Map.of())
       writeItemResponse.sdkHttpResponse(sdkHttpResponse)
       val writeCaptor: ArgumentCaptor[BatchWriteItemRequest] = ArgumentCaptor.forClass(classOf[BatchWriteItemRequest])
 


### PR DESCRIPTION
Annoyingly, `hasUnprocessedItems` only checks if `unprocessedItems` is
null but it can also come back as an empty map.
So `hasUnprocessedItems` will be true but `unprocessedItems.get(tableName)` will be
null which causes a NPE.
This check makes sure the map is not empty. I've added an empty map into
the writeItems test to make sure it works.
