### PR TITLE
DR2-1784 Batch delete items

### DIFF
--- a/dynamodb/src/main/scala/uk/gov/nationalarchives/DADynamoDBClient.scala
+++ b/dynamodb/src/main/scala/uk/gov/nationalarchives/DADynamoDBClient.scala
@@ -31,6 +31,30 @@ class DADynamoDBClient[F[_]: Async](dynamoDBClient: DynamoDbAsyncClient):
   extension [T](completableFuture: CompletableFuture[T])
     private def liftF: F[T] = Async[F].fromCompletableFuture(Async[F].pure(completableFuture))
 
+  /** Deletes a list of items with primary keys of type T from Dynamo. Unprocessed items will be retried
+    *
+    * @param tableName
+    *   The name of the table
+    * @param primaryKeys
+    *   A list of primary keys to delete from Dynamo (list can be any length; requests will be batched into groups of
+    *   25)
+    * @param format
+    *   An implicit scanamo formatter for type T
+    * @tparam T
+    *   The type of the primary keys to be deleted from Dynamo
+    * @return
+    *   The List of BatchWriteItemResponse wrapped with F[_]
+    */
+  def deleteItems[T](tableName: String, primaryKeys: List[T])(using DynamoFormat[T]): F[List[BatchWriteItemResponse]] =
+    writeOrDeleteItems(
+      tableName,
+      primaryKeys,
+      itemMap => {
+        val deleteRequest = DeleteRequest.builder().key(itemMap).build
+        WriteRequest.builder().deleteRequest(deleteRequest).build
+      }
+    )
+
   /** Writes a single item to DynamoDb
     *
     * @param dynamoDbWriteRequest
@@ -57,6 +81,7 @@ class DADynamoDBClient[F[_]: Async](dynamoDBClient: DynamoDbAsyncClient):
       .map(_.sdkHttpResponse().statusCode())
 
   /** Writes the list of items of type T to Dynamo. Unprocessed items will be retried
+    *
     * @param tableName
     *   The name of the table
     * @param items
@@ -71,30 +96,17 @@ class DADynamoDBClient[F[_]: Async](dynamoDBClient: DynamoDbAsyncClient):
   def writeItems[T <: Product](tableName: String, items: List[T])(using
       format: DynamoFormat[T]
   ): F[List[BatchWriteItemResponse]] =
-    items
-      .grouped(25)
-      .toList
-      .map { batchedItems =>
-        val valuesToWrite: List[WriteRequest] = batchedItems
-          .map(format.write)
-          .map(_.toAttributeValue.m())
-          .map { itemMap =>
-            val putRequest = PutRequest.builder().item(itemMap).build
-            WriteRequest.builder().putRequest(putRequest).build
-          }
-        Async[F].tailRecM(valuesToWrite) { reqs =>
-          val req = BatchWriteItemRequest.builder().requestItems(Map(tableName -> reqs.asJava).asJava).build()
-          dynamoDBClient.batchWriteItem(req).liftF.map {
-            case resUnprocessed
-                if resUnprocessed.hasUnprocessedItems && resUnprocessed.unprocessedItems.containsKey(tableName) =>
-              Left(resUnprocessed.unprocessedItems.get(tableName).asScala.toList)
-            case res => Right(res)
-          }
-        }
+    writeOrDeleteItems(
+      tableName,
+      items,
+      itemMap => {
+        val putRequest = PutRequest.builder().item(itemMap).build
+        WriteRequest.builder().putRequest(putRequest).build
       }
-      .sequence
+    )
 
   /** Returns a list of items of type T which match the list of primary keys
+    *
     * @param primaryKeys
     *   A list of primary keys of type K. The case class of type K should match the table primary key.
     * @param tableName
@@ -192,6 +204,34 @@ class DADynamoDBClient[F[_]: Async](dynamoDBClient: DynamoDbAsyncClient):
       .query(queryRequest)
       .liftF
       .flatMap(res => validateAndConvertAttributeValuesList(res.items()))
+
+  private def writeOrDeleteItems[T](
+      tableName: String,
+      items: List[T],
+      mapToWriteRequest: util.Map[String, AttributeValue] => WriteRequest
+  )(using
+      format: DynamoFormat[T]
+  ) = {
+    items
+      .grouped(25)
+      .toList
+      .map { batchedItems =>
+        val valuesToWrite: List[WriteRequest] = batchedItems
+          .map(format.write)
+          .map(_.toAttributeValue.m())
+          .map(mapToWriteRequest)
+        Async[F].tailRecM(valuesToWrite) { reqs =>
+          val req = BatchWriteItemRequest.builder().requestItems(Map(tableName -> reqs.asJava).asJava).build()
+          dynamoDBClient.batchWriteItem(req).liftF.map {
+            case resUnprocessed
+                if resUnprocessed.hasUnprocessedItems && resUnprocessed.unprocessedItems.containsKey(tableName) =>
+              Left(resUnprocessed.unprocessedItems.get(tableName).asScala.toList)
+            case res => Right(res)
+          }
+        }
+      }
+      .sequence
+  }
 
   private def validateAndConvertAttributeValuesList[T](
       attributeValuesList: util.List[util.Map[String, AttributeValue]]

--- a/site-docs/src/main/paradox/dynamodb/usage/fs2.md
+++ b/site-docs/src/main/paradox/dynamodb/usage/fs2.md
@@ -94,4 +94,10 @@ def queryItemsExample(tableName: String): Unit = {
     "numericAttribute" < 5 or "parentPath" === "/a/parent/path"
   )
 }
+
+def deleteItemsExample(tableName: String): IO[BatchWriteItemResponse] = {
+  val partitionKey1 = PartitionKey(partitionKeyValue1)
+  val partitionKey2 = PartitionKey(partitionKeyValue2)
+  fs2Client.deleteItems(tableName, List(partitionKey1, partitionKey2))
+}
 ```

--- a/site-docs/src/main/paradox/dynamodb/usage/index.md
+++ b/site-docs/src/main/paradox/dynamodb/usage/index.md
@@ -9,18 +9,20 @@ val clientWithCustom = new DADynamoDBClient(dynamoDbAsyncClient)
 val clientWithDefault = DADynamoDBClient()
 ```
 
-The client exposes four methods:
+The client exposes six methods:
 
 ```scala
 def writeItem(dynamoDbWriteRequest: DADynamoDbWriteItemRequest): F[Int]
 
-def writeItems[T <: Product](tableName: String, items: List[T])(implicit format: DynamoFormat[T]): F[BatchWriteItemResponse]
+def writeItems[T <: Product](tableName: String, items: List[T])(using format: DynamoFormat[T]): F[BatchWriteItemResponse]
 
-def getItems[T <: Product, K <: Product](keys: List[K], tableName: String)(implicit returnFormat: DynamoFormat[T], keyFormat: DynamoFormat[K]): F[List[T]]
+def getItems[T <: Product, K <: Product](keys: List[K], tableName: String)(using returnFormat: DynamoFormat[T], keyFormat: DynamoFormat[K]): F[List[T]]
 
 def updateAttributeValues(dynamoDbRequest: DynamoDbRequest): F[Int]
 
 def queryItems[U <: Product](tableName: String, gsiName: String, requestCondition: RequestCondition)(implicit returnTypeFormat: DynamoFormat[U]): F[List[U]]
+
+def deleteItems[T](tableName: String, primaryKeyAttributes: List[T])(using DynamoFormat[T]): F[List[BatchWriteItemResponse]]
 ```
 
 1. The `writeItem` method takes a DADynamoDbWriteItemRequest Case Class
@@ -70,7 +72,7 @@ def queryItems[U <: Product](tableName: String, gsiName: String, requestConditio
 
 5. The `queryItems` method takes a table name of type `String`, a global secondary index name and a Scanamo filter query. The query is converted to a Scanamo `RequestCondition` using implicits in the companion object.
 
-
+6. The `deleteItems` method takes a table name of type `String` and a list of objects of type `T` These objects represent a primary key in Dynamo and the implicit `DynamoFormat[T]` is used to convert the case classes.
 @@@ index
 
 * [Zio](zio.md)

--- a/site-docs/src/main/paradox/dynamodb/usage/zio.md
+++ b/site-docs/src/main/paradox/dynamodb/usage/zio.md
@@ -45,7 +45,7 @@ def getItemsExample(tableName: String, partitionKeyValue1: String, partitionKeyV
 }
 
 def writeItemExample(tableName: String, attributeName: String, attributeName2: String, newAttributeValue: String,
-                     newAttributeValue2: String): IO[Int] = {
+                     newAttributeValue2: String): Task[Int] = {
 
   val dynamoDbWriteItemRequest = DADynamoDbWriteItemRequest(
     tableName,
@@ -99,6 +99,12 @@ def queryItemsExample(tableName: String, gsiName: String): Unit = {
     gsiName,
     "numericAttribute" < 5 or "parentPath" === "/a/parent/path"
   )
+}
+
+def deleteItemsExample(tableName: String): Task[BatchWriteItemResponse] = {
+  val partitionKey1 = PartitionKey(partitionKeyValue1)
+  val partitionKey2 = PartitionKey(partitionKeyValue2)
+  zioClient.deleteItems(tableName, List(partitionKey1, partitionKey2))
 }
 
 ```


### PR DESCRIPTION
The call to batchWriteItem can also be used for deleting items. The only
difference is the write request. I've moved the existing writeItem logic
to a private method with a parameter for the write request and the
writeItems and deleteItems methods call this.

I've put another table in the tests so the existing writeItems tests are
now being called with deleteItems as well.
