### PR TITLE
restructure sns and dynamo clients

### DIFF
--- a/dynamodb/src/main/scala/uk/gov/nationalarchives/DADynamoDBClient.scala
+++ b/dynamodb/src/main/scala/uk/gov/nationalarchives/DADynamoDBClient.scala
@@ -11,7 +11,7 @@ import software.amazon.awssdk.http.async.SdkAsyncHttpClient
 import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
-import software.amazon.awssdk.services.dynamodb.model.*
+import software.amazon.awssdk.services.dynamodb.model.{KeysAndAttributes, *}
 import uk.gov.nationalarchives.DADynamoDBClient.*
 
 import java.util
@@ -22,14 +22,10 @@ import scala.language.{implicitConversions, postfixOps}
 /** An DynamoDbAsync client. It is written generically so can be used for any effect which has an Async instance.
   * Requires an implicit instance of cats Async which is used to convert CompletableFuture to F
   *
-  * @param dynamoDBClient
-  *   An AWS DynamoDb Async client
   * @tparam F
   *   Type of the effect
   */
-class DADynamoDBClient[F[_]: Async](dynamoDBClient: DynamoDbAsyncClient):
-  extension [T](completableFuture: CompletableFuture[T])
-    private def liftF: F[T] = Async[F].fromCompletableFuture(Async[F].pure(completableFuture))
+trait DADynamoDBClient[F[_]: Async]:
 
   /** Deletes a list of items with primary keys of type T from Dynamo. Unprocessed items will be retried
     *
@@ -45,15 +41,7 @@ class DADynamoDBClient[F[_]: Async](dynamoDBClient: DynamoDbAsyncClient):
     * @return
     *   The List of BatchWriteItemResponse wrapped with F[_]
     */
-  def deleteItems[T](tableName: String, primaryKeys: List[T])(using DynamoFormat[T]): F[List[BatchWriteItemResponse]] =
-    writeOrDeleteItems(
-      tableName,
-      primaryKeys,
-      itemMap => {
-        val deleteRequest = DeleteRequest.builder().key(itemMap).build
-        WriteRequest.builder().deleteRequest(deleteRequest).build
-      }
-    )
+  def deleteItems[T](tableName: String, primaryKeys: List[T])(using DynamoFormat[T]): F[List[BatchWriteItemResponse]]
 
   /** Writes a single item to DynamoDb
     *
@@ -63,22 +51,7 @@ class DADynamoDBClient[F[_]: Async](dynamoDBClient: DynamoDbAsyncClient):
     * @return
     *   The http status code from the writeItem call wrapped with F[_]
     */
-  def writeItem(dynamoDbWriteRequest: DADynamoDbWriteItemRequest): F[Int] =
-    val putItemRequestBuilder = PutItemRequest
-      .builder()
-      .tableName(dynamoDbWriteRequest.tableName)
-      .item(dynamoDbWriteRequest.attributeNamesAndValuesToWrite.asJava)
-
-    val putItemRequest: PutItemRequest =
-      dynamoDbWriteRequest.conditionalExpression
-        .map(putItemRequestBuilder.conditionExpression)
-        .getOrElse(putItemRequestBuilder)
-        .build
-
-    dynamoDBClient
-      .putItem(putItemRequest)
-      .liftF
-      .map(_.sdkHttpResponse().statusCode())
+  def writeItem(dynamoDbWriteRequest: DADynamoDbWriteItemRequest): F[Int]
 
   /** Writes the list of items of type T to Dynamo. Unprocessed items will be retried
     *
@@ -93,17 +66,31 @@ class DADynamoDBClient[F[_]: Async](dynamoDBClient: DynamoDbAsyncClient):
     * @return
     *   The List of BatchWriteItemResponse wrapped with F[_]
     */
-  def writeItems[T <: Product](tableName: String, items: List[T])(using
+  def writeItems[T](tableName: String, items: List[T])(using
       format: DynamoFormat[T]
-  ): F[List[BatchWriteItemResponse]] =
-    writeOrDeleteItems(
-      tableName,
-      items,
-      itemMap => {
-        val putRequest = PutRequest.builder().item(itemMap).build
-        WriteRequest.builder().putRequest(putRequest).build
-      }
-    )
+  ): F[List[BatchWriteItemResponse]]
+
+  /** @param tableName
+    *   The name of the table
+    * @param gsiName
+    *   The name of the global secondary index
+    * @param requestCondition
+    *   This is not passed in directly. You construct either a Query[_] or a ConditionExpression instance. This is then
+    *   converted to RequestCondition by the implicits in the companion object.
+    * @param returnTypeFormat
+    *   An implicit scanamo formatter for return type U
+    * @tparam U
+    *   The return type for the function
+    * @return
+    *   A list of type U wrapped in the F effect
+    */
+  def queryItems[U](tableName: String, gsiName: String, requestCondition: RequestCondition)(using
+      returnTypeFormat: DynamoFormat[U]
+  ): F[List[U]]
+
+  def queryItems[U](tableName: String, requestCondition: RequestCondition)(using
+      returnTypeFormat: DynamoFormat[U]
+  ): F[List[U]]
 
   /** Returns a list of items of type T which match the list of primary keys
     *
@@ -122,26 +109,10 @@ class DADynamoDBClient[F[_]: Async](dynamoDBClient: DynamoDbAsyncClient):
     * @return
     *   A list of case classes of type T which the values populated from Dynamo, wrapped with F[_]
     */
-  def getItems[T <: Product, K <: Product](primaryKeys: List[K], tableName: String)(using
+  def getItems[T, K](primaryKeys: List[K], tableName: String)(using
       returnFormat: DynamoFormat[T],
       keyFormat: DynamoFormat[K]
-  ): F[List[T]] =
-    val primaryKeysAsAttributeValues = primaryKeys
-      .map(keyFormat.write)
-      .map(_.toAttributeValue.m())
-      .asJava
-
-    val keysAndAttributes = KeysAndAttributes.builder
-      .keys(primaryKeysAsAttributeValues)
-      .build
-    val batchGetItemRequest = BatchGetItemRequest.builder
-      .requestItems(Map(tableName -> keysAndAttributes).asJava)
-      .build
-
-    for
-      batchResponse <- dynamoDBClient.batchGetItem(batchGetItemRequest).liftF
-      result <- validateAndConvertAttributeValuesList[T](batchResponse.responses.get(tableName))
-    yield result
+  ): F[List[T]]
 
   /** Updates an attribute in DynamoDb
     *
@@ -151,100 +122,7 @@ class DADynamoDBClient[F[_]: Async](dynamoDBClient: DynamoDbAsyncClient):
     * @return
     *   The http status code from the updateAttributeValues call wrapped with F[_]
     */
-  def updateAttributeValues(dynamoDbRequest: DADynamoDbRequest): F[Int] =
-    val attributeValueUpdates =
-      dynamoDbRequest.attributeNamesAndValuesToUpdate.map { case (name, attributeValue) =>
-        name -> AttributeValueUpdate
-          .builder()
-          .action(AttributeAction.PUT)
-          .value(attributeValue.get)
-          .build()
-      } asJava
-
-    val updateAttributeValueRequest = UpdateItemRequest
-      .builder()
-      .tableName(dynamoDbRequest.tableName)
-      .key(dynamoDbRequest.primaryKeyAndItsValue asJava)
-      .attributeUpdates(attributeValueUpdates)
-      .build()
-
-    dynamoDBClient
-      .updateItem(updateAttributeValueRequest)
-      .liftF
-      .map(_.sdkHttpResponse().statusCode())
-
-  /** @param tableName
-    *   The name of the table
-    * @param gsiName
-    *   The name of the global secondary index
-    * @param requestCondition
-    *   This is not passed in directly. You construct either a Query[_] or a ConditionExpression instance. This is then
-    *   converted to RequestCondition by the implicits in the companion object.
-    * @param returnTypeFormat
-    *   An implicit scanamo formatter for return type U
-    * @tparam U
-    *   The return type for the function
-    * @return
-    *   A list of type U wrapped in the F effect
-    */
-  def queryItems[U <: Product](tableName: String, gsiName: String, requestCondition: RequestCondition)(using
-      returnTypeFormat: DynamoFormat[U]
-  ): F[List[U]] =
-    val expressionAttributeValues =
-      requestCondition.dynamoValues.flatMap(_.toExpressionAttributeValues).getOrElse(util.Collections.emptyMap())
-
-    val queryRequest = QueryRequest.builder
-      .tableName(tableName)
-      .indexName(gsiName)
-      .keyConditionExpression(requestCondition.expression)
-      .expressionAttributeNames(requestCondition.attributeNames.asJava)
-      .expressionAttributeValues(expressionAttributeValues)
-      .build
-    dynamoDBClient
-      .query(queryRequest)
-      .liftF
-      .flatMap(res => validateAndConvertAttributeValuesList(res.items()))
-
-  private def writeOrDeleteItems[T](
-      tableName: String,
-      items: List[T],
-      mapToWriteRequest: util.Map[String, AttributeValue] => WriteRequest
-  )(using
-      format: DynamoFormat[T]
-  ) = {
-    items
-      .grouped(25)
-      .toList
-      .map { batchedItems =>
-        val valuesToWrite: List[WriteRequest] = batchedItems
-          .map(format.write)
-          .map(_.toAttributeValue.m())
-          .map(mapToWriteRequest)
-        Async[F].tailRecM(valuesToWrite) { reqs =>
-          val req = BatchWriteItemRequest.builder().requestItems(Map(tableName -> reqs.asJava).asJava).build()
-          dynamoDBClient.batchWriteItem(req).liftF.map {
-            case resUnprocessed
-                if resUnprocessed.hasUnprocessedItems && resUnprocessed.unprocessedItems.containsKey(tableName) =>
-              Left(resUnprocessed.unprocessedItems.get(tableName).asScala.toList)
-            case res => Right(res)
-          }
-        }
-      }
-      .sequence
-  }
-
-  private def validateAndConvertAttributeValuesList[T](
-      attributeValuesList: util.List[util.Map[String, AttributeValue]]
-  )(using format: DynamoFormat[T]): F[List[T]] = {
-    attributeValuesList.asScala.toList.map { res =>
-      DynamoValue.fromMap:
-        res.asScala.toMap.map { case (name, av) =>
-          name -> DynamoValue.fromAttributeValue(av)
-        }
-    } map { dynamoValue =>
-      format.read(dynamoValue).left.map(err => new RuntimeException(err.show))
-    } map Async[F].fromEither
-  }.sequence
+  def updateAttributeValues(dynamoDbRequest: DADynamoDbRequest): F[Int]
 
 object DADynamoDBClient:
 
@@ -256,14 +134,6 @@ object DADynamoDBClient:
   given [T: UniqueKeyCondition, U: UniqueKeyCondition](using
       qkc: QueryableKeyCondition[AndEqualsCondition[T, U]]
   ): Conversion[AndEqualsCondition[T, U], RequestCondition] = qkc.apply(_)
-
-  private lazy val httpClient: SdkAsyncHttpClient = NettyNioAsyncHttpClient.builder().build()
-  private lazy val dynamoDBClient: DynamoDbAsyncClient = DynamoDbAsyncClient
-    .builder()
-    .httpClient(httpClient)
-    .region(Region.EU_WEST_2)
-    .credentialsProvider(DefaultCredentialsProvider.create())
-    .build()
 
   case class DADynamoDbRequest(
       tableName: String,
@@ -277,4 +147,170 @@ object DADynamoDBClient:
       conditionalExpression: Option[String] = None
   )
 
-  def apply[F[_]: Async]() = new DADynamoDBClient[F](dynamoDBClient)
+  def apply[F[_]: Async](): DADynamoDBClient[F] = {
+    lazy val httpClient: SdkAsyncHttpClient = NettyNioAsyncHttpClient.builder().build()
+    lazy val dynamoDBClient: DynamoDbAsyncClient = DynamoDbAsyncClient
+      .builder()
+      .httpClient(httpClient)
+      .region(Region.EU_WEST_2)
+      .credentialsProvider(DefaultCredentialsProvider.create())
+      .build()
+    DADynamoDBClient(dynamoDBClient)
+  }
+
+  def apply[F[_]: Async](dynamoDBClient: DynamoDbAsyncClient): DADynamoDBClient[F] = new DADynamoDBClient[F] {
+    extension [T](completableFuture: CompletableFuture[T])
+      private def liftF: F[T] = Async[F].fromCompletableFuture(Async[F].pure(completableFuture))
+
+    override def deleteItems[T](tableName: String, primaryKeys: List[T])(using
+        DynamoFormat[T]
+    ): F[List[BatchWriteItemResponse]] =
+      writeOrDeleteItems(
+        tableName,
+        primaryKeys,
+        itemMap => {
+          val deleteRequest = DeleteRequest.builder().key(itemMap).build
+          WriteRequest.builder().deleteRequest(deleteRequest).build
+        }
+      )
+
+    override def writeItem(dynamoDbWriteRequest: DADynamoDbWriteItemRequest): F[Int] =
+      val putItemRequestBuilder = PutItemRequest
+        .builder()
+        .tableName(dynamoDbWriteRequest.tableName)
+        .item(dynamoDbWriteRequest.attributeNamesAndValuesToWrite.asJava)
+
+      val putItemRequest: PutItemRequest =
+        dynamoDbWriteRequest.conditionalExpression
+          .map(putItemRequestBuilder.conditionExpression)
+          .getOrElse(putItemRequestBuilder)
+          .build
+
+      dynamoDBClient
+        .putItem(putItemRequest)
+        .liftF
+        .map(_.sdkHttpResponse().statusCode())
+
+    override def writeItems[T](tableName: String, items: List[T])(using
+        format: DynamoFormat[T]
+    ): F[List[BatchWriteItemResponse]] =
+      writeOrDeleteItems(
+        tableName,
+        items,
+        itemMap => {
+          val putRequest = PutRequest.builder().item(itemMap).build
+          WriteRequest.builder().putRequest(putRequest).build
+        }
+      )
+
+    override def getItems[T, K](primaryKeys: List[K], tableName: String)(using
+        returnFormat: DynamoFormat[T],
+        keyFormat: DynamoFormat[K]
+    ): F[List[T]] =
+      val primaryKeysAsAttributeValues = primaryKeys
+        .map(keyFormat.write)
+        .map(_.toAttributeValue.m())
+        .asJava
+
+      val keysAndAttributes = KeysAndAttributes.builder
+        .keys(primaryKeysAsAttributeValues)
+        .build
+      val batchGetItemRequest = BatchGetItemRequest.builder
+        .requestItems(Map(tableName -> keysAndAttributes).asJava)
+        .build
+
+      for
+        batchResponse <- dynamoDBClient.batchGetItem(batchGetItemRequest).liftF
+        result <- validateAndConvertAttributeValuesList[T](batchResponse.responses.get(tableName))
+      yield result
+
+    override def updateAttributeValues(dynamoDbRequest: DADynamoDbRequest): F[Int] =
+      val attributeValueUpdates =
+        dynamoDbRequest.attributeNamesAndValuesToUpdate.map { case (name, attributeValue) =>
+          name -> AttributeValueUpdate
+            .builder()
+            .action(AttributeAction.PUT)
+            .value(attributeValue.get)
+            .build()
+        } asJava
+
+      val updateAttributeValueRequest = UpdateItemRequest
+        .builder()
+        .tableName(dynamoDbRequest.tableName)
+        .key(dynamoDbRequest.primaryKeyAndItsValue asJava)
+        .attributeUpdates(attributeValueUpdates)
+        .build()
+
+      dynamoDBClient
+        .updateItem(updateAttributeValueRequest)
+        .liftF
+        .map(_.sdkHttpResponse().statusCode())
+
+    override def queryItems[U](tableName: String, gsiName: String, requestCondition: RequestCondition)(using
+        returnTypeFormat: DynamoFormat[U]
+    ): F[List[U]] = queryItems(tableName, Option(gsiName), requestCondition)
+
+    override def queryItems[U](tableName: String, requestCondition: RequestCondition)(using
+        returnTypeFormat: DynamoFormat[U]
+    ): F[List[U]] =
+      queryItems(tableName, None, requestCondition)
+
+    private def queryItems[T](tableName: String, potentialGsi: Option[String], requestCondition: RequestCondition)(using
+        returnTypeFormat: DynamoFormat[T]
+    ) =
+      val expressionAttributeValues =
+        requestCondition.dynamoValues.flatMap(_.toExpressionAttributeValues).getOrElse(util.Collections.emptyMap())
+
+      val builder = QueryRequest.builder
+        .tableName(tableName)
+        .keyConditionExpression(requestCondition.expression)
+        .expressionAttributeNames(requestCondition.attributeNames.asJava)
+        .expressionAttributeValues(expressionAttributeValues)
+
+      val queryRequest = potentialGsi.map(gsi => builder.indexName(gsi)).getOrElse(builder).build
+      dynamoDBClient
+        .query(queryRequest)
+        .liftF
+        .flatMap(res => validateAndConvertAttributeValuesList(res.items()))
+
+    private def writeOrDeleteItems[T](
+        tableName: String,
+        items: List[T],
+        mapToWriteRequest: util.Map[String, AttributeValue] => WriteRequest
+    )(using
+        format: DynamoFormat[T]
+    ) = {
+      items
+        .grouped(25)
+        .toList
+        .map { batchedItems =>
+          val valuesToWrite: List[WriteRequest] = batchedItems
+            .map(format.write)
+            .map(_.toAttributeValue.m())
+            .map(mapToWriteRequest)
+          Async[F].tailRecM(valuesToWrite) { reqs =>
+            val req = BatchWriteItemRequest.builder().requestItems(Map(tableName -> reqs.asJava).asJava).build()
+            dynamoDBClient.batchWriteItem(req).liftF.map {
+              case resUnprocessed
+                  if resUnprocessed.hasUnprocessedItems && resUnprocessed.unprocessedItems.containsKey(tableName) =>
+                Left(resUnprocessed.unprocessedItems.get(tableName).asScala.toList)
+              case res => Right(res)
+            }
+          }
+        }
+        .sequence
+    }
+
+    private def validateAndConvertAttributeValuesList[T](
+        attributeValuesList: util.List[util.Map[String, AttributeValue]]
+    )(using format: DynamoFormat[T]): F[List[T]] = {
+      attributeValuesList.asScala.toList.map { res =>
+        DynamoValue.fromMap:
+          res.asScala.toMap.map { case (name, av) =>
+            name -> DynamoValue.fromAttributeValue(av)
+          }
+      } map { dynamoValue =>
+        format.read(dynamoValue).left.map(err => new RuntimeException(err.show))
+      } map Async[F].fromEither
+    }.sequence
+  }

--- a/dynamodb/src/main/scala/uk/gov/nationalarchives/DADynamoDBClient.scala
+++ b/dynamodb/src/main/scala/uk/gov/nationalarchives/DADynamoDBClient.scala
@@ -7,7 +7,6 @@ import org.scanamo.*
 import org.scanamo.query.{Condition as ScanamoCondition, *}
 import org.scanamo.request.RequestCondition
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
-import software.amazon.awssdk.http.async.SdkAsyncHttpClient
 import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
@@ -76,7 +75,7 @@ trait DADynamoDBClient[F[_]: Async]:
   /** @param tableName
     *   The name of the table
     * @param gsiName
-    *   The name of the global secondary index
+    *   The optional name of the global secondary index
     * @param requestCondition
     *   This is not passed in directly. You construct either a Query[_] or a ConditionExpression instance. This is then
     *   converted to RequestCondition by the implicits in the companion object.
@@ -87,12 +86,8 @@ trait DADynamoDBClient[F[_]: Async]:
     * @return
     *   A list of type U wrapped in the F effect
     */
-  def queryItems[U](tableName: String, gsiName: String, requestCondition: RequestCondition)(using
-      returnTypeFormat: DynamoFormat[U]
-  ): F[List[U]]
-
-  def queryItems[U](tableName: String, requestCondition: RequestCondition)(using
-      returnTypeFormat: DynamoFormat[U]
+  def queryItems[U](tableName: String, requestCondition: RequestCondition, potentialGsiName: Option[String] = None)(
+      using returnTypeFormat: DynamoFormat[U]
   ): F[List[U]]
 
   /** Returns a list of items of type T which match the list of primary keys
@@ -150,170 +145,158 @@ object DADynamoDBClient:
       conditionalExpression: Option[String] = None
   )
 
-  def apply[F[_]: Async](): DADynamoDBClient[F] = {
-    lazy val httpClient: SdkAsyncHttpClient = NettyNioAsyncHttpClient.builder().build()
-    lazy val dynamoDBClient: DynamoDbAsyncClient = DynamoDbAsyncClient
-      .builder()
-      .httpClient(httpClient)
-      .region(Region.EU_WEST_2)
-      .credentialsProvider(DefaultCredentialsProvider.create())
-      .build()
-    DADynamoDBClient(dynamoDBClient)
-  }
+  private lazy val dynamoDBClient: DynamoDbAsyncClient = DynamoDbAsyncClient
+    .builder()
+    .httpClient(NettyNioAsyncHttpClient.builder().build())
+    .region(Region.EU_WEST_2)
+    .credentialsProvider(DefaultCredentialsProvider.create())
+    .build()
 
-  def apply[F[_]: Async](dynamoDBClient: DynamoDbAsyncClient): DADynamoDBClient[F] = new DADynamoDBClient[F] {
-    extension [T](completableFuture: CompletableFuture[T])
-      private def liftF: F[T] = Async[F].fromCompletableFuture(Async[F].pure(completableFuture))
+  def apply[F[_]: Async](dynamoDBClient: DynamoDbAsyncClient = dynamoDBClient): DADynamoDBClient[F] =
+    new DADynamoDBClient[F] {
+      extension [T](completableFuture: CompletableFuture[T])
+        private def liftF: F[T] = Async[F].fromCompletableFuture(Async[F].pure(completableFuture))
 
-    override def deleteItems[T](tableName: String, primaryKeyAttributes: List[T])(using
-        DynamoFormat[T]
-    ): F[List[BatchWriteItemResponse]] =
-      writeOrDeleteItems(
-        tableName,
-        primaryKeyAttributes,
-        primaryKeyAttributesMap => {
-          val deleteRequest = DeleteRequest.builder().key(primaryKeyAttributesMap).build
-          WriteRequest.builder().deleteRequest(deleteRequest).build
-        }
-      )
+      override def deleteItems[T](tableName: String, primaryKeyAttributes: List[T])(using
+          DynamoFormat[T]
+      ): F[List[BatchWriteItemResponse]] =
+        writeOrDeleteItems(
+          tableName,
+          primaryKeyAttributes,
+          primaryKeyAttributesMap => {
+            val deleteRequest = DeleteRequest.builder().key(primaryKeyAttributesMap).build
+            WriteRequest.builder().deleteRequest(deleteRequest).build
+          }
+        )
 
-    override def writeItem(dynamoDbWriteRequest: DADynamoDbWriteItemRequest): F[Int] =
-      val putItemRequestBuilder = PutItemRequest
-        .builder()
-        .tableName(dynamoDbWriteRequest.tableName)
-        .item(dynamoDbWriteRequest.attributeNamesAndValuesToWrite.asJava)
+      override def writeItem(dynamoDbWriteRequest: DADynamoDbWriteItemRequest): F[Int] =
+        val putItemRequestBuilder = PutItemRequest
+          .builder()
+          .tableName(dynamoDbWriteRequest.tableName)
+          .item(dynamoDbWriteRequest.attributeNamesAndValuesToWrite.asJava)
 
-      val putItemRequest: PutItemRequest =
-        dynamoDbWriteRequest.conditionalExpression
-          .map(putItemRequestBuilder.conditionExpression)
-          .getOrElse(putItemRequestBuilder)
+        val putItemRequest: PutItemRequest =
+          dynamoDbWriteRequest.conditionalExpression
+            .map(putItemRequestBuilder.conditionExpression)
+            .getOrElse(putItemRequestBuilder)
+            .build
+
+        dynamoDBClient
+          .putItem(putItemRequest)
+          .liftF
+          .map(_.sdkHttpResponse().statusCode())
+
+      override def writeItems[T](tableName: String, items: List[T])(using
+          format: DynamoFormat[T]
+      ): F[List[BatchWriteItemResponse]] =
+        writeOrDeleteItems(
+          tableName,
+          items,
+          itemMap => {
+            val putRequest = PutRequest.builder().item(itemMap).build
+            WriteRequest.builder().putRequest(putRequest).build
+          }
+        )
+
+      override def getItems[T, K](primaryKeys: List[K], tableName: String)(using
+          returnFormat: DynamoFormat[T],
+          keyFormat: DynamoFormat[K]
+      ): F[List[T]] =
+        val primaryKeysAsAttributeValues = primaryKeys
+          .map(keyFormat.write)
+          .map(_.toAttributeValue.m())
+          .asJava
+
+        val keysAndAttributes = KeysAndAttributes.builder
+          .keys(primaryKeysAsAttributeValues)
+          .build
+        val batchGetItemRequest = BatchGetItemRequest.builder
+          .requestItems(Map(tableName -> keysAndAttributes).asJava)
           .build
 
-      dynamoDBClient
-        .putItem(putItemRequest)
-        .liftF
-        .map(_.sdkHttpResponse().statusCode())
+        for
+          batchResponse <- dynamoDBClient.batchGetItem(batchGetItemRequest).liftF
+          result <- validateAndConvertAttributeValuesList[T](batchResponse.responses.get(tableName))
+        yield result
 
-    override def writeItems[T](tableName: String, items: List[T])(using
-        format: DynamoFormat[T]
-    ): F[List[BatchWriteItemResponse]] =
-      writeOrDeleteItems(
-        tableName,
-        items,
-        itemMap => {
-          val putRequest = PutRequest.builder().item(itemMap).build
-          WriteRequest.builder().putRequest(putRequest).build
-        }
-      )
+      override def updateAttributeValues(dynamoDbRequest: DADynamoDbRequest): F[Int] =
+        val attributeValueUpdates =
+          dynamoDbRequest.attributeNamesAndValuesToUpdate.map { case (name, attributeValue) =>
+            name -> AttributeValueUpdate
+              .builder()
+              .action(AttributeAction.PUT)
+              .value(attributeValue.get)
+              .build()
+          } asJava
 
-    override def getItems[T, K](primaryKeys: List[K], tableName: String)(using
-        returnFormat: DynamoFormat[T],
-        keyFormat: DynamoFormat[K]
-    ): F[List[T]] =
-      val primaryKeysAsAttributeValues = primaryKeys
-        .map(keyFormat.write)
-        .map(_.toAttributeValue.m())
-        .asJava
+        val updateAttributeValueRequest = UpdateItemRequest
+          .builder()
+          .tableName(dynamoDbRequest.tableName)
+          .key(dynamoDbRequest.primaryKeyAndItsValue asJava)
+          .attributeUpdates(attributeValueUpdates)
+          .build()
 
-      val keysAndAttributes = KeysAndAttributes.builder
-        .keys(primaryKeysAsAttributeValues)
-        .build
-      val batchGetItemRequest = BatchGetItemRequest.builder
-        .requestItems(Map(tableName -> keysAndAttributes).asJava)
-        .build
+        dynamoDBClient
+          .updateItem(updateAttributeValueRequest)
+          .liftF
+          .map(_.sdkHttpResponse().statusCode())
 
-      for
-        batchResponse <- dynamoDBClient.batchGetItem(batchGetItemRequest).liftF
-        result <- validateAndConvertAttributeValuesList[T](batchResponse.responses.get(tableName))
-      yield result
+      def queryItems[U](tableName: String, requestCondition: RequestCondition, potentialGsiName: Option[String] = None)(
+          using returnTypeFormat: DynamoFormat[U]
+      ): F[List[U]] =
+        val expressionAttributeValues =
+          requestCondition.dynamoValues.flatMap(_.toExpressionAttributeValues).getOrElse(util.Collections.emptyMap())
 
-    override def updateAttributeValues(dynamoDbRequest: DADynamoDbRequest): F[Int] =
-      val attributeValueUpdates =
-        dynamoDbRequest.attributeNamesAndValuesToUpdate.map { case (name, attributeValue) =>
-          name -> AttributeValueUpdate
-            .builder()
-            .action(AttributeAction.PUT)
-            .value(attributeValue.get)
-            .build()
-        } asJava
+        val builder = QueryRequest.builder
+          .tableName(tableName)
+          .keyConditionExpression(requestCondition.expression)
+          .expressionAttributeNames(requestCondition.attributeNames.asJava)
+          .expressionAttributeValues(expressionAttributeValues)
 
-      val updateAttributeValueRequest = UpdateItemRequest
-        .builder()
-        .tableName(dynamoDbRequest.tableName)
-        .key(dynamoDbRequest.primaryKeyAndItsValue asJava)
-        .attributeUpdates(attributeValueUpdates)
-        .build()
+        val queryRequest = potentialGsiName.map(gsi => builder.indexName(gsi)).getOrElse(builder).build
+        dynamoDBClient
+          .query(queryRequest)
+          .liftF
+          .flatMap(res => validateAndConvertAttributeValuesList(res.items()))
 
-      dynamoDBClient
-        .updateItem(updateAttributeValueRequest)
-        .liftF
-        .map(_.sdkHttpResponse().statusCode())
-
-    override def queryItems[U](tableName: String, gsiName: String, requestCondition: RequestCondition)(using
-        returnTypeFormat: DynamoFormat[U]
-    ): F[List[U]] = queryItems(tableName, Option(gsiName), requestCondition)
-
-    override def queryItems[U](tableName: String, requestCondition: RequestCondition)(using
-        returnTypeFormat: DynamoFormat[U]
-    ): F[List[U]] =
-      queryItems(tableName, None, requestCondition)
-
-    private def queryItems[T](tableName: String, potentialGsi: Option[String], requestCondition: RequestCondition)(using
-        returnTypeFormat: DynamoFormat[T]
-    ) =
-      val expressionAttributeValues =
-        requestCondition.dynamoValues.flatMap(_.toExpressionAttributeValues).getOrElse(util.Collections.emptyMap())
-
-      val builder = QueryRequest.builder
-        .tableName(tableName)
-        .keyConditionExpression(requestCondition.expression)
-        .expressionAttributeNames(requestCondition.attributeNames.asJava)
-        .expressionAttributeValues(expressionAttributeValues)
-
-      val queryRequest = potentialGsi.map(gsi => builder.indexName(gsi)).getOrElse(builder).build
-      dynamoDBClient
-        .query(queryRequest)
-        .liftF
-        .flatMap(res => validateAndConvertAttributeValuesList(res.items()))
-
-    private def writeOrDeleteItems[T](
-        tableName: String,
-        items: List[T],
-        mapToWriteRequest: util.Map[String, AttributeValue] => WriteRequest
-    )(using
-        format: DynamoFormat[T]
-    ) = {
-      items
-        .grouped(25)
-        .toList
-        .map { batchedItems =>
-          val valuesToWrite: List[WriteRequest] = batchedItems
-            .map(format.write)
-            .map(_.toAttributeValue.m())
-            .map(mapToWriteRequest)
-          Async[F].tailRecM(valuesToWrite) { reqs =>
-            val req = BatchWriteItemRequest.builder().requestItems(Map(tableName -> reqs.asJava).asJava).build()
-            dynamoDBClient.batchWriteItem(req).liftF.map {
-              case resUnprocessed
-                  if resUnprocessed.hasUnprocessedItems && resUnprocessed.unprocessedItems.containsKey(tableName) =>
-                Left(resUnprocessed.unprocessedItems.get(tableName).asScala.toList)
-              case res => Right(res)
+      private def writeOrDeleteItems[T](
+          tableName: String,
+          items: List[T],
+          mapToWriteRequest: util.Map[String, AttributeValue] => WriteRequest
+      )(using
+          format: DynamoFormat[T]
+      ) = {
+        items
+          .grouped(25)
+          .toList
+          .map { batchedItems =>
+            val valuesToWrite: List[WriteRequest] = batchedItems
+              .map(format.write)
+              .map(_.toAttributeValue.m())
+              .map(mapToWriteRequest)
+            Async[F].tailRecM(valuesToWrite) { reqs =>
+              val req = BatchWriteItemRequest.builder().requestItems(Map(tableName -> reqs.asJava).asJava).build()
+              dynamoDBClient.batchWriteItem(req).liftF.map {
+                case resUnprocessed
+                    if resUnprocessed.hasUnprocessedItems && resUnprocessed.unprocessedItems.containsKey(tableName) =>
+                  Left(resUnprocessed.unprocessedItems.get(tableName).asScala.toList)
+                case res => Right(res)
+              }
             }
           }
-        }
-        .sequence
-    }
+          .sequence
+      }
 
-    private def validateAndConvertAttributeValuesList[T](
-        attributeValuesList: util.List[util.Map[String, AttributeValue]]
-    )(using format: DynamoFormat[T]): F[List[T]] = {
-      attributeValuesList.asScala.toList.map { res =>
-        DynamoValue.fromMap:
-          res.asScala.toMap.map { case (name, av) =>
-            name -> DynamoValue.fromAttributeValue(av)
-          }
-      } map { dynamoValue =>
-        format.read(dynamoValue).left.map(err => new RuntimeException(err.show))
-      } map Async[F].fromEither
-    }.sequence
-  }
+      private def validateAndConvertAttributeValuesList[T](
+          attributeValuesList: util.List[util.Map[String, AttributeValue]]
+      )(using format: DynamoFormat[T]): F[List[T]] = {
+        attributeValuesList.asScala.toList.map { res =>
+          DynamoValue.fromMap:
+            res.asScala.toMap.map { case (name, av) =>
+              name -> DynamoValue.fromAttributeValue(av)
+            }
+        } map { dynamoValue =>
+          format.read(dynamoValue).left.map(err => new RuntimeException(err.show))
+        } map Async[F].fromEither
+      }.sequence
+    }

--- a/dynamodb/src/main/scala/uk/gov/nationalarchives/DADynamoDBClient.scala
+++ b/dynamodb/src/main/scala/uk/gov/nationalarchives/DADynamoDBClient.scala
@@ -74,7 +74,7 @@ trait DADynamoDBClient[F[_]: Async]:
 
   /** @param tableName
     *   The name of the table
-    * @param gsiName
+    * @param potentialGsiName
     *   The optional name of the global secondary index
     * @param requestCondition
     *   This is not passed in directly. You construct either a Query[_] or a ConditionExpression instance. This is then

--- a/dynamodb/src/test/scala/uk/gov/nationalarchives/DADynamoDBClientTest.scala
+++ b/dynamodb/src/test/scala/uk/gov/nationalarchives/DADynamoDBClientTest.scala
@@ -451,7 +451,7 @@ class DADynamoDBClientTest
 
       val client = DADynamoDBClient[IO](mockDynamoDbAsyncClient)
 
-      client.queryItems[MockSingleAttributeRequest]("testTable", "indexName", query).unsafeRunSync()
+      client.queryItems[MockSingleAttributeRequest]("testTable", query, Option("indexName")).unsafeRunSync()
 
       val queryRequestValue = queryRequestCaptor.getValue
 
@@ -479,7 +479,7 @@ class DADynamoDBClientTest
 
     val client = createDynamoClientFromItems(items)
     val queryItemsResponseF: IO[List[MockTwoAttributesRequest]] =
-      client.queryItems[MockTwoAttributesRequest]("testTable", "indexName", "mockAttribute" > 0)
+      client.queryItems[MockTwoAttributesRequest]("testTable", "mockAttribute" > 0, Option("indexName"))
     val queryItemsResponse = queryItemsResponseF.unsafeRunSync()
 
     queryItemsResponse.head.mockAttribute should equal("mockAttributeValue")
@@ -496,8 +496,8 @@ class DADynamoDBClientTest
     val queryItemsResponse = client
       .queryItems[MockTwoAttributesRequest](
         "testTable",
-        "indexName",
-        "mockAttribute" === "mockAttributeValue" and "asdasd" === ""
+        "mockAttribute" === "mockAttributeValue" and "asdasd" === "",
+        Option("indexName")
       )
       .unsafeRunSync()
 
@@ -514,7 +514,11 @@ class DADynamoDBClientTest
 
     val ex = intercept[Exception] {
       client
-        .queryItems[MockSingleAttributeRequest]("testTable", "indexName", "mockAttribute" === "mockAttributeValue")
+        .queryItems[MockSingleAttributeRequest](
+          "testTable",
+          "mockAttribute" === "mockAttributeValue",
+          Option("indexName")
+        )
         .unsafeRunSync()
     }
     ex.getMessage should equal("'mockAttribute': not of type: 'S' was 'DynNum(1)'")
@@ -529,7 +533,7 @@ class DADynamoDBClientTest
 
     val ex = intercept[Exception] {
       client
-        .queryItems[MockNestedRequest]("testTable", "indexName", "mockAttribute" === "mockAttributeValue")
+        .queryItems[MockNestedRequest]("testTable", "mockAttribute" === "mockAttributeValue", Option("indexName"))
         .unsafeRunSync()
     }
     ex.getMessage should equal("'mockSingleAttributeResponse': missing")
@@ -546,7 +550,7 @@ class DADynamoDBClientTest
 
     val ex = intercept[Exception] {
       client
-        .queryItems[MockNestedRequest]("testTable", "indexName", "mockAttribute" === "mockAttributeValue")
+        .queryItems[MockNestedRequest]("testTable", "mockAttribute" === "mockAttributeValue", Option("indexName"))
         .unsafeRunSync()
     }
     ex.getMessage should be("Table name could not be found")

--- a/dynamodb/src/test/scala/uk/gov/nationalarchives/DADynamoDBClientTest.scala
+++ b/dynamodb/src/test/scala/uk/gov/nationalarchives/DADynamoDBClientTest.scala
@@ -65,7 +65,7 @@ class DADynamoDBClientTest
 
       when(mockDynamoDbAsyncClient.batchGetItem(getBatchItemCaptor.capture())).thenReturn(clientGetItemResponseInCf)
 
-      val client = new DADynamoDBClient[IO](mockDynamoDbAsyncClient)
+      val client = DADynamoDBClient[IO](mockDynamoDbAsyncClient)
 
       val result = client.getItems[MockSingleAttributeRequest, Pk](keys, "mockTableName").unsafeRunSync()
 
@@ -99,7 +99,7 @@ class DADynamoDBClientTest
 
     when(mockDynamoDbAsyncClient.batchGetItem(any[BatchGetItemRequest])).thenReturn(clientGetItemResponseInCf)
 
-    val client = new DADynamoDBClient[IO](mockDynamoDbAsyncClient)
+    val client = DADynamoDBClient[IO](mockDynamoDbAsyncClient)
 
     val getAttributeValueResponse: List[MockTwoAttributesRequest] =
       client.getItems[MockTwoAttributesRequest, Pk](List(Pk("mockPrimaryKeyValue")), "mockTableName").unsafeRunSync()
@@ -127,7 +127,7 @@ class DADynamoDBClientTest
 
     when(mockDynamoDbAsyncClient.batchGetItem(any[BatchGetItemRequest])).thenReturn(clientGetItemResponseInCf)
 
-    val client = new DADynamoDBClient[IO](mockDynamoDbAsyncClient)
+    val client = DADynamoDBClient[IO](mockDynamoDbAsyncClient)
 
     val getAttributeValueResponse: List[MockTwoAttributesRequest] =
       client.getItems[MockTwoAttributesRequest, Pk](List(Pk("mockPrimaryKeyValue")), "mockTableName").unsafeRunSync()
@@ -152,7 +152,7 @@ class DADynamoDBClientTest
 
     when(mockDynamoDbAsyncClient.batchGetItem(any[BatchGetItemRequest])).thenReturn(clientGetItemResponseInCf)
 
-    val client = new DADynamoDBClient[IO](mockDynamoDbAsyncClient)
+    val client = DADynamoDBClient[IO](mockDynamoDbAsyncClient)
 
     val ex = intercept[Exception] {
       client.getItems[MockSingleAttributeRequest, Pk](List(Pk("mockPrimaryKeyValue")), "mockTableName").unsafeRunSync()
@@ -177,7 +177,7 @@ class DADynamoDBClientTest
 
     when(mockDynamoDbAsyncClient.batchGetItem(any[BatchGetItemRequest])).thenReturn(clientGetItemResponseInCf)
 
-    val client = new DADynamoDBClient[IO](mockDynamoDbAsyncClient)
+    val client = DADynamoDBClient[IO](mockDynamoDbAsyncClient)
 
     val ex = intercept[Exception] {
       client.getItems[MockNestedRequest, Pk](List(Pk("mockPrimaryKeyValue")), "mockTableName").unsafeRunSync()
@@ -192,7 +192,7 @@ class DADynamoDBClientTest
       ResourceNotFoundException.builder.message("Table name could not be found").build()
     )
 
-    val client = new DADynamoDBClient[IO](mockDynamoDbAsyncClient)
+    val client = DADynamoDBClient[IO](mockDynamoDbAsyncClient)
 
     val getAttributeValueEx = intercept[Exception] {
       client.getItems[MockSingleAttributeRequest, Pk](List(Pk("id")), "table").unsafeRunSync()
@@ -216,7 +216,7 @@ class DADynamoDBClientTest
 
     when(mockDynamoDbAsyncClient.updateItem(updateItemCaptor.capture())).thenReturn(clientGetItemResponseInCf)
 
-    val client = new DADynamoDBClient[IO](mockDynamoDbAsyncClient)
+    val client = DADynamoDBClient[IO](mockDynamoDbAsyncClient)
 
     val dynamoDbRequest =
       DADynamoDbRequest(
@@ -250,7 +250,7 @@ class DADynamoDBClientTest
 
     when(mockDynamoDbAsyncClient.updateItem(any[UpdateItemRequest])).thenReturn(clientGetItemResponseInCf)
 
-    val client = new DADynamoDBClient[IO](mockDynamoDbAsyncClient)
+    val client = DADynamoDBClient[IO](mockDynamoDbAsyncClient)
 
     val dynamoDbRequest =
       DADynamoDbRequest(
@@ -269,7 +269,7 @@ class DADynamoDBClientTest
       ResourceNotFoundException.builder.message("Table name could not be found").build()
     )
 
-    val client = new DADynamoDBClient[IO](mockDynamoDbAsyncClient)
+    val client = DADynamoDBClient[IO](mockDynamoDbAsyncClient)
 
     val dynamoDbRequest =
       DADynamoDbRequest(
@@ -350,7 +350,7 @@ class DADynamoDBClientTest
 
         when(mockDynamoDbAsyncClient.batchWriteItem(writeCaptor.capture()))
           .thenReturn(CompletableFuture.completedFuture(writeItemResponse.build()))
-        val client = new DADynamoDBClient[IO](mockDynamoDbAsyncClient)
+        val client = DADynamoDBClient[IO](mockDynamoDbAsyncClient)
         val responses = writeOrDeleteFunction(client, "table", input).unsafeRunSync()
 
         responses.foreach(_.sdkHttpResponse().statusCode() should equal(200))
@@ -388,7 +388,7 @@ class DADynamoDBClientTest
       when(mockDynamoDbAsyncClient.batchWriteItem(writeCaptor.capture()))
         .thenReturn(CompletableFuture.completedFuture(writeItemResponseWithUnprocessed))
         .thenReturn(CompletableFuture.completedFuture(BatchWriteItemResponse.builder.build))
-      val client = new DADynamoDBClient[IO](mockDynamoDbAsyncClient)
+      val client = DADynamoDBClient[IO](mockDynamoDbAsyncClient)
 
       val responses = writeOrDeleteFunction(client, "table", input).unsafeRunSync()
 
@@ -411,7 +411,7 @@ class DADynamoDBClientTest
       when(mockDynamoDbAsyncClient.batchWriteItem(any[BatchWriteItemRequest]))
         .thenThrow(new RuntimeException("Error writing to dynamo"))
 
-      val client = new DADynamoDBClient[IO](mockDynamoDbAsyncClient)
+      val client = DADynamoDBClient[IO](mockDynamoDbAsyncClient)
       val ex = intercept[Exception] {
         writeOrDeleteFunction(client, "table", List(MockSingleAttributeRequest("mockValue"))).unsafeRunSync()
       }
@@ -449,7 +449,7 @@ class DADynamoDBClientTest
 
       when(mockDynamoDbAsyncClient.query(queryRequestCaptor.capture())).thenReturn(clientQueryResponseInCf)
 
-      val client = new DADynamoDBClient[IO](mockDynamoDbAsyncClient)
+      val client = DADynamoDBClient[IO](mockDynamoDbAsyncClient)
 
       client.queryItems[MockSingleAttributeRequest]("testTable", "indexName", query).unsafeRunSync()
 
@@ -542,7 +542,7 @@ class DADynamoDBClientTest
       ResourceNotFoundException.builder.message("Table name could not be found").build()
     )
 
-    val client = new DADynamoDBClient[IO](mockDynamoDbAsyncClient)
+    val client = DADynamoDBClient[IO](mockDynamoDbAsyncClient)
 
     val ex = intercept[Exception] {
       client
@@ -570,7 +570,7 @@ class DADynamoDBClientTest
 
         when(mockDynamoDbAsyncClient.putItem(putItemRequestCaptor.capture())).thenReturn(clientPutItemResponseInCf)
 
-        val client = new DADynamoDBClient[IO](mockDynamoDbAsyncClient)
+        val client = DADynamoDBClient[IO](mockDynamoDbAsyncClient)
 
         val dynamoDbWriteItemRequest =
           DADynamoDbWriteItemRequest(
@@ -609,7 +609,7 @@ class DADynamoDBClientTest
 
     when(mockDynamoDbAsyncClient.putItem(any[PutItemRequest])).thenReturn(clientPutItemResponseInCf)
 
-    val client = new DADynamoDBClient[IO](mockDynamoDbAsyncClient)
+    val client = DADynamoDBClient[IO](mockDynamoDbAsyncClient)
 
     val dynamoDbWriteItemRequest =
       DADynamoDbWriteItemRequest(
@@ -627,7 +627,7 @@ class DADynamoDBClientTest
       ResourceNotFoundException.builder.message("Table name could not be found").build()
     )
 
-    val client = new DADynamoDBClient[IO](mockDynamoDbAsyncClient)
+    val client = DADynamoDBClient[IO](mockDynamoDbAsyncClient)
 
     val dynamoDbWriteItemRequest =
       DADynamoDbWriteItemRequest(
@@ -653,6 +653,6 @@ class DADynamoDBClientTest
     val clientQueryResponseInCf: CompletableFuture[QueryResponse] = CompletableFuture.completedFuture(queryResponse)
 
     when(mockDynamoDbAsyncClient.query(any[QueryRequest])).thenReturn(clientQueryResponseInCf)
-    new DADynamoDBClient[IO](mockDynamoDbAsyncClient)
+    DADynamoDBClient[IO](mockDynamoDbAsyncClient)
   }
 }

--- a/sns/src/test/scala/uk/gov/nationalarchives/DASNSClientTest.scala
+++ b/sns/src/test/scala/uk/gov/nationalarchives/DASNSClientTest.scala
@@ -30,7 +30,7 @@ class DASNSClientTest extends AnyFlatSpec with MockitoSugar {
     val mockResponse = CompletableFuture.completedFuture(PublishBatchResponse.builder().build())
     when(snsAsyncClient.publishBatch(publishCaptor.capture())).thenReturn(mockResponse)
 
-    val client = new DASNSClient[IO](snsAsyncClient)
+    val client = DASNSClient[IO](snsAsyncClient)
     client
       .publish("mockTopicArn")(List(Test("testMessage1", "testValue1"), Test("testMessage2", "testValue2")))
       .unsafeRunSync()
@@ -55,7 +55,7 @@ class DASNSClientTest extends AnyFlatSpec with MockitoSugar {
     val messages = (1 to 23).toList.map(number => Test(s"testMessage$number", s"testValue$number"))
     val convertNumberToJsonMessage = (number: Int) => s"""{"message":"testMessage$number","value":"testValue$number"}"""
 
-    val client = new DASNSClient[IO](snsAsyncClient)
+    val client = DASNSClient[IO](snsAsyncClient)
     client.publish("mockTopicArn")(messages).unsafeRunSync()
 
     val publishedBatchRequests: List[PublishBatchRequest] = publishCaptor.getAllValues.asScala.toList
@@ -82,7 +82,7 @@ class DASNSClientTest extends AnyFlatSpec with MockitoSugar {
     val snsAsyncClient = mock[SnsAsyncClient]
     when(snsAsyncClient.publishBatch(any[PublishBatchRequest])).thenThrow(new RuntimeException("Error sending message"))
 
-    val client = new DASNSClient[IO](snsAsyncClient)
+    val client = DASNSClient[IO](snsAsyncClient)
 
     val ex = intercept[Exception] {
       client
@@ -103,7 +103,7 @@ class DASNSClientTest extends AnyFlatSpec with MockitoSugar {
     val messages = (1 to 15).toList.map(number => Test(s"testMessage$number", s"testValue$number"))
     val convertNumberToJsonMessage = (number: Int) => s"""{"message":"testMessage$number","value":"testValue$number"}"""
 
-    val client = new DASNSClient[IO](snsAsyncClient)
+    val client = DASNSClient[IO](snsAsyncClient)
     val ex = intercept[Exception] {
       client.publish("mockTopicArn")(messages).unsafeRunSync()
     }
@@ -136,7 +136,7 @@ class DASNSClientTest extends AnyFlatSpec with MockitoSugar {
     val messages = (1 to 15).toList.map(number => Test(s"testMessage$number", s"testValue$number"))
     val convertNumberToJsonMessage = (number: Int) => s"""{"message":"testMessage$number","value":"testValue$number"}"""
 
-    val client = new DASNSClient[IO](snsAsyncClient)
+    val client = DASNSClient[IO](snsAsyncClient)
     val ex = intercept[Exception] {
       client.publish("mockTopicArn")(messages).unsafeRunSync()
     }


### PR DESCRIPTION
I've changed these around so they have a trait and the apply method
creates an implementation of that trait. This will make it easier to
provide our own test traits in the unit tests.

I've also got rid of all the <: Product