### PR TITLE
Add delay seconds parameter.

### DIFF
--- a/site-docs/src/main/paradox/sqs/usage/fs2.md
+++ b/site-docs/src/main/paradox/sqs/usage/fs2.md
@@ -25,6 +25,7 @@ import io.circe.generic.auto._ // Used to provide Encoder[T] and Decoder[T] but 
     res1 <- sendMessageFn(Message("message1"))
     res2 <- sendMessageFn(Message("message2"))
     res3 <- sendMessageFn(Message("message2"), Option(FifoQueueConfiguration("messageGroupId", "messageDeduplicationId")))
+    res4 <- sendMessageFn(Message("message2"), None, 10)
   } yield List(res1.sequenceNumber(), res2.sequenceNumber(), res3.sequenceNumber())
 
   val receivedMessages: IO[List[MessageResponse[Message]]] = for {

--- a/site-docs/src/main/paradox/sqs/usage/index.md
+++ b/site-docs/src/main/paradox/sqs/usage/index.md
@@ -4,7 +4,7 @@ The client exposes three methods
 ```scala
 case class FifoQueueConfiguration(messageGroupId: String, messageDeduplicationId: String)
 
-def sendMessage[T](queueUrl: String)(message: T, potentialFifoConfiguration: Option[FifoQueueConfiguration] = None)(using enc: Encoder[T]): F[SendMessageResponse]
+def sendMessage[T](queueUrl: String)(message: T, potentialFifoConfiguration: Option[FifoQueueConfiguration] = None, delaySeconds: Int = 0)(using enc: Encoder[T]): F[SendMessageResponse]
 
 def receiveMessages[T](queueUrl: String, maxNumberOfMessages: Int = 10)(implicit dec: Decoder[T]): F[List[MessageResponse[T]]]
 

--- a/sqs/src/main/scala/uk/gov/nationalarchives/DASQSClient.scala
+++ b/sqs/src/main/scala/uk/gov/nationalarchives/DASQSClient.scala
@@ -45,7 +45,7 @@ trait DASQSClient[F[_]]:
     */
   def sendMessage[T <: Product](
       queueUrl: String
-  )(message: T, potentialFifoConfiguration: Option[FifoQueueConfiguration] = None)(using
+  )(message: T, potentialFifoConfiguration: Option[FifoQueueConfiguration] = None, delaySeconds: Int = 0)(using
       enc: Encoder[T]
   ): F[SendMessageResponse]
 
@@ -87,12 +87,13 @@ object DASQSClient:
   def apply[F[_]: Async](sqsAsyncClient: SqsAsyncClient = sqsAsyncClient): DASQSClient[F] = new DASQSClient[F] {
     def sendMessage[T <: Product](
         queueUrl: String
-    )(message: T, potentialFifoConfiguration: Option[FifoQueueConfiguration] = None)(using
+    )(message: T, potentialFifoConfiguration: Option[FifoQueueConfiguration] = None, delaySeconds: Int = 0)(using
         enc: Encoder[T]
     ): F[SendMessageResponse] =
       val messageRequestBuilder = SendMessageRequest.builder
         .queueUrl(queueUrl)
         .messageBody(message.asJson.printWith(Printer.noSpaces))
+        .delaySeconds(delaySeconds)
 
       val messageRequest = potentialFifoConfiguration
         .map { fifoQueueConfiguration =>


### PR DESCRIPTION
This will let us use the aggregator code for custodial copy. We want to
send a message but we don't want it to be picked up until the batch
window expires.
