### PR TITLE
DR2-1950 Allow assuming a role for the client.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -85,6 +85,7 @@ lazy val s3 = (project in file("s3"))
     description := "A project containing useful methods for interacting with S3",
     libraryDependencies ++= Seq(
       s3Sdk,
+      stsSdk,
       transferManager,
       awsCrt,
       reactorTest % Test

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,6 +16,7 @@ object Dependencies {
   lazy val mockito = "org.scalatestplus" %% "mockito-5-10" % s"3.2.18.0"
   lazy val reactorTest = "io.projectreactor" % "reactor-test" % "3.6.10"
   lazy val s3Sdk = "software.amazon.awssdk" % "s3" % awsSdkVersion
+  lazy val stsSdk = "software.amazon.awssdk" % "sts" % awsSdkVersion
   lazy val scalaTest = "org.scalatest" %% "scalatest" % scalaTestVersion
   lazy val scanamo = "org.scanamo" %% "scanamo" % "2.0.0"
   lazy val snsSdk = "software.amazon.awssdk" % "sns" % awsSdkVersion

--- a/site-docs/src/main/paradox/s3/usage/index.md
+++ b/site-docs/src/main/paradox/s3/usage/index.md
@@ -1,11 +1,14 @@
 # S3 Client
 
-The client constructor takes a `S3TransferManager` object. The default `apply` method passes one in with sensible defaults but you can pass your own in if necessary.
+## Creating new instances 
 
 ```scala
 val customTransferManager: S3TransferManager = ???
-val clientWithCustom = new DAS3Client(customTransferManager)
+val customAsyncClient: S3AsyncClient = ???
 
+val clientWithTransferManagerAndClient = DAS3Client[IO](customTransferManager, customAsyncClient)
+val clientWithAsyncClient = DAS3Client[IO](customAsyncClient)
+val clientWithAssumeRole = DAS3Client[IO]("role-arn-to-assume", "role-session-name")
 val clientWithDefault = DAS3Client()
 ```
 


### PR DESCRIPTION
We're changing the opex creators so they write directly into
Preservica's bucket. To do that, we need to create a client with an
assumed role.
