### PR TITLE
DR2-1997 Create methods for flow control lambda

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -78,6 +78,17 @@ lazy val eventBridge = (project in file("eventbridge"))
     )
   )
 
+lazy val ssm = (project in file("ssm"))
+  .settings(commonSettings)
+  .settings(
+    name := "da-ssm-client",
+    description := "A project containing useful methods for interacting with SSM",
+    libraryDependencies ++= Seq(
+      ssmSdk,
+      circeParser
+    )
+  )
+
 lazy val s3 = (project in file("s3"))
   .settings(commonSettings)
   .settings(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,6 +22,7 @@ object Dependencies {
   lazy val snsSdk = "software.amazon.awssdk" % "sns" % awsSdkVersion
   lazy val sfnSdk = "software.amazon.awssdk" % "sfn" % awsSdkVersion
   lazy val sqsSdk = "software.amazon.awssdk" % "sqs" % awsSdkVersion
+  lazy val ssmSdk = "software.amazon.awssdk" % "ssm" % awsSdkVersion
   lazy val secretsManagerSdk = "software.amazon.awssdk" % "secretsmanager" % awsSdkVersion
   lazy val transferManager = "software.amazon.awssdk" % "s3-transfer-manager" % awsSdkVersion
 }

--- a/secretsmanager/src/main/scala/uk/gov/nationalarchives/DASecretsManagerClient.scala
+++ b/secretsmanager/src/main/scala/uk/gov/nationalarchives/DASecretsManagerClient.scala
@@ -122,8 +122,8 @@ object DASecretsManagerClient:
     .build()
 
   def apply[F[_]: Async](
-      secretsManagerAsyncClient: SecretsManagerAsyncClient = secretsManagerAsyncClient,
-      secretId: String
+      secretId: String,
+      secretsManagerAsyncClient: SecretsManagerAsyncClient = secretsManagerAsyncClient
   ): DASecretsManagerClient[F] =
     new DASecretsManagerClient[F] {
 

--- a/secretsmanager/src/test/scala/uk/gov/nationalarchives/DASecretsManagerClientTest.scala
+++ b/secretsmanager/src/test/scala/uk/gov/nationalarchives/DASecretsManagerClientTest.scala
@@ -63,7 +63,7 @@ class DASecretsManagerClientTest extends AnyFlatSpec with MockitoSugar with Befo
   "generateRandomPassword" should "return an error if the client returns an error" in {
     when(secretsManagerAsyncClient.getRandomPassword(any[GetRandomPasswordRequest]))
       .thenThrow(new RuntimeException("Error from client"))
-    val client = DASecretsManagerClient[IO](secretsManagerAsyncClient, secretId)
+    val client = DASecretsManagerClient[IO](secretId, secretsManagerAsyncClient)
     val ex = intercept[Exception] {
       client.generateRandomPassword().unsafeRunSync()
     }
@@ -88,7 +88,7 @@ class DASecretsManagerClientTest extends AnyFlatSpec with MockitoSugar with Befo
   "describeSecret" should "return an error if the client returns an error" in {
     when(secretsManagerAsyncClient.describeSecret(any[DescribeSecretRequest]))
       .thenThrow(new RuntimeException("Error from client"))
-    val client = DASecretsManagerClient[IO](secretsManagerAsyncClient, secretId)
+    val client = DASecretsManagerClient[IO](secretId, secretsManagerAsyncClient)
     val ex = intercept[Exception] {
       client.describeSecret().unsafeRunSync()
     }
@@ -154,7 +154,7 @@ class DASecretsManagerClientTest extends AnyFlatSpec with MockitoSugar with Befo
   "getSecretValue" should "return an error if the client returns an error" in {
     when(secretsManagerAsyncClient.getSecretValue(any[GetSecretValueRequest]))
       .thenThrow(new RuntimeException("Error from client"))
-    val client = DASecretsManagerClient[IO](secretsManagerAsyncClient, secretId)
+    val client = DASecretsManagerClient[IO](secretId, secretsManagerAsyncClient)
     val ex = intercept[Exception] {
       client.getSecretValue[SecretResponse]().unsafeRunSync()
     }
@@ -205,7 +205,7 @@ class DASecretsManagerClientTest extends AnyFlatSpec with MockitoSugar with Befo
   "putSecretValue" should "return an error if the client returns an error" in {
     when(secretsManagerAsyncClient.putSecretValue(any[PutSecretValueRequest]))
       .thenThrow(new RuntimeException("Error from client"))
-    val client = DASecretsManagerClient[IO](secretsManagerAsyncClient, secretId)
+    val client = DASecretsManagerClient[IO](secretId, secretsManagerAsyncClient)
     val ex = intercept[Exception] {
       client.putSecretValue(SecretRequest("secret")).unsafeRunSync()
     }
@@ -241,7 +241,7 @@ class DASecretsManagerClientTest extends AnyFlatSpec with MockitoSugar with Befo
   "updateSecretVersionStage" should "return an error if the client returns an error" in {
     when(secretsManagerAsyncClient.updateSecretVersionStage(any[UpdateSecretVersionStageRequest]))
       .thenThrow(new RuntimeException("Error from client"))
-    val client = DASecretsManagerClient[IO](secretsManagerAsyncClient, secretId)
+    val client = DASecretsManagerClient[IO](secretId, secretsManagerAsyncClient)
     val ex = intercept[Exception] {
       client.updateSecretVersionStage("moveToVersion", "removeFromVersion").unsafeRunSync()
     }
@@ -275,7 +275,7 @@ class DASecretsManagerClientTest extends AnyFlatSpec with MockitoSugar with Befo
       fnToTest: T => CompletableFuture[R],
       mockResponse: R
   )(using classTag: ClassTag[T]): (DASecretsManagerClient[IO], ArgumentCaptor[T]) = {
-    val client = DASecretsManagerClient[IO](secretsManagerAsyncClient, secretId)
+    val client = DASecretsManagerClient[IO](secretId, secretsManagerAsyncClient)
     val requestCaptor: ArgumentCaptor[T] = ArgumentCaptor.forClass(classTag.runtimeClass.asInstanceOf[Class[T]])
     val response: CompletableFuture[R] = CompletableFuture.completedFuture(mockResponse)
     when(fnToTest.apply(requestCaptor.capture())).thenReturn(response)

--- a/sfn/src/main/scala/uk/gov/nationalarchives/DASFNClient.scala
+++ b/sfn/src/main/scala/uk/gov/nationalarchives/DASFNClient.scala
@@ -1,13 +1,23 @@
 package uk.gov.nationalarchives
 
 import cats.effect.Async
+import cats.implicits.*
+import io.circe.syntax.*
 import io.circe.{Encoder, Printer}
-import io.circe.syntax._
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient
 import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.sfn.SfnAsyncClient
-import software.amazon.awssdk.services.sfn.model.{StartExecutionRequest, StartExecutionResponse}
+import software.amazon.awssdk.services.sfn.model.{
+  ListExecutionsRequest,
+  SendTaskSuccessRequest,
+  StartExecutionRequest,
+  StartExecutionResponse
+}
+import uk.gov.nationalarchives.DASFNClient.Status
+
+import java.util.concurrent.CompletableFuture
+import scala.jdk.CollectionConverters.*
 
 /** An SFN client. It is written generically so can be used for any effect which has an Async instance. Requires an
   * implicit instance of cats Async which is used to convert CompletableFuture to F
@@ -34,9 +44,39 @@ trait DASFNClient[F[_]: Async]:
       enc: Encoder[T]
   ): F[StartExecutionResponse]
 
+  def listStepFunctions(stepFunctionArn: String, status: Status): F[List[String]]
+
+  def sendTaskSuccess(taskToken: String): F[Unit]
+
 object DASFNClient:
 
+  extension [F[_]: Async, T](completableFuture: CompletableFuture[T])
+    private def liftF: F[T] = Async[F].fromCompletableFuture(Async[F].pure(completableFuture))
+
+  enum Status(val sdkStatus: String):
+    case Running extends Status("RUNNING")
+    case Succeeded extends Status("SUCCEEDED")
+    case Failed extends Status("FAILED")
+
   def apply[F[_]: Async](sfnAsyncClient: SfnAsyncClient): DASFNClient[F] = new DASFNClient[F]:
+
+    override def sendTaskSuccess(taskToken: String): F[Unit] = {
+      val sendTaskSuccessRequest = SendTaskSuccessRequest.builder
+        .taskToken(taskToken)
+        .build
+      sfnAsyncClient.sendTaskSuccess(sendTaskSuccessRequest).liftF.void
+    }
+
+    override def listStepFunctions(stepFunctionArn: String, status: Status): F[List[String]] = {
+      val listExecutionsRequest = ListExecutionsRequest.builder
+        .stateMachineArn(stepFunctionArn)
+        .statusFilter(status.sdkStatus)
+        .build
+      sfnAsyncClient.listExecutions(listExecutionsRequest).liftF.map { response =>
+        response.executions().asScala.toList.map(_.name)
+      }
+    }
+
     override def startExecution[T <: Product](stateMachineArn: String, input: T, name: Option[String] = None)(using
         enc: Encoder[T]
     ): F[StartExecutionResponse] =

--- a/sfn/src/main/scala/uk/gov/nationalarchives/DASFNClient.scala
+++ b/sfn/src/main/scala/uk/gov/nationalarchives/DASFNClient.scala
@@ -57,6 +57,9 @@ object DASFNClient:
     case Running extends Status("RUNNING")
     case Succeeded extends Status("SUCCEEDED")
     case Failed extends Status("FAILED")
+    case TimedOut extends Status("TIMED_OUT")
+    case Aborted extends Status("ABORTED")
+    case PendingRedrive extends Status("PENDING_REDRIVE")
 
   def apply[F[_]: Async](sfnAsyncClient: SfnAsyncClient): DASFNClient[F] = new DASFNClient[F]:
 

--- a/sfn/src/test/scala/uk/gov/nationalarchives/DASFNClientTest.scala
+++ b/sfn/src/test/scala/uk/gov/nationalarchives/DASFNClientTest.scala
@@ -3,66 +3,184 @@ package uk.gov.nationalarchives
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import io.circe.Encoder
-import org.mockito.ArgumentCaptor
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.when
+import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers.*
-import org.scalatestplus.mockito.MockitoSugar
 import software.amazon.awssdk.services.sfn.SfnAsyncClient
-import software.amazon.awssdk.services.sfn.model.{StartExecutionRequest, StartExecutionResponse}
+import software.amazon.awssdk.services.sfn.model.*
+import uk.gov.nationalarchives.DASFNClient.Status.*
 
 import java.util.concurrent.CompletableFuture
+import scala.collection.mutable.ListBuffer
+import scala.jdk.CollectionConverters.*
 
-class DASFNClientTest extends AnyFlatSpec with MockitoSugar {
+class DASFNClientTest extends AnyFlatSpec with EitherValues {
   case class TestInput(message: String, value: String)
 
+  case class SfnExecutions(name: String, sfnArn: String, input: String, status: String, taskToken: String = "")
   given Encoder[TestInput] = Encoder.forProduct2("message", "value")(t => (t.message, t.value))
   val arn = "arn:aws:states:eu-west-2:123456789:stateMachine:TestStateMachine"
 
+  case class Errors(startExecution: Boolean = false, listExecutions: Boolean = false, sendTaskSuccess: Boolean = false)
+
+  def createClient(initial: ListBuffer[SfnExecutions], errors: Option[Errors] = None): SfnAsyncClient =
+    new SfnAsyncClient:
+      override def serviceName(): String = "test"
+
+      override def close(): Unit = ()
+
+      override def startExecution(
+          startExecutionRequest: StartExecutionRequest
+      ): CompletableFuture[StartExecutionResponse] =
+        if errors.exists(_.startExecution) then throw new Exception("Error starting execution")
+        else {
+          initial += SfnExecutions(
+            startExecutionRequest.name(),
+            startExecutionRequest.stateMachineArn(),
+            startExecutionRequest.input(),
+            "running"
+          )
+          CompletableFuture.completedFuture(StartExecutionResponse.builder.build)
+        }
+
+      override def listExecutions(
+          listExecutionsRequest: ListExecutionsRequest
+      ): CompletableFuture[ListExecutionsResponse] = {
+        if errors.exists(_.listExecutions) then throw new Exception("Error listing executions")
+        else
+          CompletableFuture.completedFuture {
+            val executions = initial
+              .filter(i =>
+                i.sfnArn == listExecutionsRequest
+                  .stateMachineArn() && i.status == listExecutionsRequest.statusFilter().toString.toLowerCase()
+              )
+              .map { execution =>
+                ExecutionListItem.builder.name(execution.name).stateMachineArn(execution.sfnArn).build
+              }
+            ListExecutionsResponse.builder.executions(executions.asJava).build
+          }
+      }
+
+      override def sendTaskSuccess(
+          sendTaskSuccessRequest: SendTaskSuccessRequest
+      ): CompletableFuture[SendTaskSuccessResponse] = {
+        if errors.exists(_.sendTaskSuccess) then throw new Exception("Error sending task success")
+        else
+          initial
+            .find(_.taskToken == sendTaskSuccessRequest.taskToken())
+            .map { sfnExection =>
+              CompletableFuture.completedFuture(SendTaskSuccessResponse.builder.build)
+            }
+            .getOrElse(
+              throw TaskDoesNotExistException.builder
+                .message(s"Task ${sendTaskSuccessRequest.taskToken()} does not exist")
+                .build
+            )
+      }
+
   "startExecution" should "start an execution with the correct parameters when no name is provided" in {
-    val sfnAsyncClient = mock[SfnAsyncClient]
-    val startExecutionRequestCaptor: ArgumentCaptor[StartExecutionRequest] =
-      ArgumentCaptor.forClass(classOf[StartExecutionRequest])
-    val mockResponse = CompletableFuture.completedFuture(StartExecutionResponse.builder().build())
-    when(sfnAsyncClient.startExecution(startExecutionRequestCaptor.capture())).thenReturn(mockResponse)
+    val sfnExecutions = ListBuffer[SfnExecutions]()
+    val sfnAsyncClient = createClient(sfnExecutions)
 
     val client = DASFNClient[IO](sfnAsyncClient)
     client.startExecution(arn, TestInput("testMessage", "testValue")).unsafeRunSync()
 
-    val request = startExecutionRequestCaptor.getValue
+    val request = sfnExecutions.head
     Option(request.name).isDefined should be(false)
-    request.stateMachineArn should be(arn)
+    request.sfnArn should be(arn)
     request.input should be("""{"message":"testMessage","value":"testValue"}""")
   }
 
   "startExecution" should "start an execution with the specified name if one is provided" in {
-    val sfnAsyncClient = mock[SfnAsyncClient]
-    val startExecutionRequestCaptor: ArgumentCaptor[StartExecutionRequest] =
-      ArgumentCaptor.forClass(classOf[StartExecutionRequest])
-    val mockResponse = CompletableFuture.completedFuture(StartExecutionResponse.builder().build())
-    when(sfnAsyncClient.startExecution(startExecutionRequestCaptor.capture())).thenReturn(mockResponse)
+    val sfnExecutions = ListBuffer[SfnExecutions]()
+    val sfnAsyncClient = createClient(sfnExecutions)
 
     val client = DASFNClient[IO](sfnAsyncClient)
-
     client.startExecution(arn, TestInput("testMessage", "testValue"), Option("testName")).unsafeRunSync()
 
-    val request = startExecutionRequestCaptor.getValue
+    val request = sfnExecutions.head
     request.name should be("testName")
-    request.stateMachineArn should be(arn)
+    request.sfnArn should be(arn)
     request.input should be("""{"message":"testMessage","value":"testValue"}""")
   }
 
   "startExecution" should "return an error if there is an error from the SFN API" in {
-    val sfnAsyncClient = mock[SfnAsyncClient]
-    when(sfnAsyncClient.startExecution(any[StartExecutionRequest]))
-      .thenThrow(new RuntimeException("Error starting execution"))
+    val sfnExecutions = ListBuffer[SfnExecutions]()
+    val sfnAsyncClient = createClient(sfnExecutions, errors = Option(Errors(startExecution = true)))
 
+    val client = DASFNClient[IO](sfnAsyncClient)
+    val ex = intercept[Exception] {
+      client.startExecution(arn, TestInput("testMessage", "testValue"), Option("testName")).attempt.unsafeRunSync()
+    }
+
+    ex.getMessage should equal("Error starting execution")
+  }
+
+  "listExecutions" should "list executions with the correct status and arn" in {
+    val initialExecutions = ListBuffer(
+      SfnExecutions("name1running", "arn1", "", "running"),
+      SfnExecutions("name2failed", "arn2", "", "failed"),
+      SfnExecutions("name2running", "arn2", "", "running")
+    )
+    val sfnAsyncClient = createClient(initialExecutions)
+    val client = DASFNClient[IO](sfnAsyncClient)
+
+    val runningArn2 = client.listStepFunctions("arn2", Running).unsafeRunSync()
+    val failedArn2 = client.listStepFunctions("arn2", Failed).unsafeRunSync()
+    val runningArn1 = client.listStepFunctions("arn1", Running).unsafeRunSync()
+
+    runningArn2.size should equal(1)
+    runningArn1.size should equal(1)
+    failedArn2.size should equal(1)
+
+    runningArn2.head should equal("name2running")
+    runningArn1.head should equal("name1running")
+    failedArn2.head should equal("name2failed")
+  }
+
+  "listExecutions" should "return an error if there is an error from AWS" in {
+    val initialExecutions = ListBuffer[SfnExecutions]()
+    val sfnAsyncClient = createClient(initialExecutions, errors = Option(Errors(listExecutions = true)))
     val client = DASFNClient[IO](sfnAsyncClient)
 
     val ex = intercept[Exception] {
-      client.startExecution(arn, TestInput("testMessage", "testValue"), Option("testName")).unsafeRunSync()
+      client.listStepFunctions("arn2", Running).attempt.unsafeRunSync()
     }
-    ex.getMessage should equal("Error starting execution")
+
+    ex.getMessage should equal("Error listing executions")
+  }
+
+  "sendTaskSuccess" should "return no errors if the task token is valid" in {
+    val initialExecutions = ListBuffer(
+      SfnExecutions("name1running", "arn1", "", "running", "taskToken")
+    )
+    val sfnAsyncClient = createClient(initialExecutions)
+    val client = DASFNClient[IO](sfnAsyncClient)
+
+    client.sendTaskSuccess("taskToken").unsafeRunSync()
+  }
+
+  "sendTaskSuccess" should "return an error if the task token is invalid" in {
+    val initialExecutions = ListBuffer(
+      SfnExecutions("name1running", "arn1", "", "running", "taskToken")
+    )
+    val sfnAsyncClient = createClient(initialExecutions)
+    val client = DASFNClient[IO](sfnAsyncClient)
+
+    val ex = intercept[TaskDoesNotExistException] {
+      client.sendTaskSuccess("invalidTaskToken").unsafeRunSync()
+    }
+    ex.getMessage should equal("Task invalidTaskToken does not exist")
+  }
+
+  "sendTaskSuccess" should "return an error if there is an error with the sdk" in {
+    val initialExecutions = ListBuffer[SfnExecutions]()
+    val sfnAsyncClient = createClient(initialExecutions, errors = Option(Errors(sendTaskSuccess = true)))
+    val client = DASFNClient[IO](sfnAsyncClient)
+
+    val ex = intercept[Exception] {
+      client.sendTaskSuccess("taskToken").unsafeRunSync()
+    }
+    ex.getMessage should equal("Error sending task success")
   }
 }

--- a/sfn/src/test/scala/uk/gov/nationalarchives/DASFNClientTest.scala
+++ b/sfn/src/test/scala/uk/gov/nationalarchives/DASFNClientTest.scala
@@ -3,7 +3,6 @@ package uk.gov.nationalarchives
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import io.circe.Encoder
-import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers.*
 import software.amazon.awssdk.services.sfn.SfnAsyncClient
@@ -14,7 +13,7 @@ import java.util.concurrent.CompletableFuture
 import scala.collection.mutable.ListBuffer
 import scala.jdk.CollectionConverters.*
 
-class DASFNClientTest extends AnyFlatSpec with EitherValues {
+class DASFNClientTest extends AnyFlatSpec {
   case class TestInput(message: String, value: String)
 
   case class SfnExecutions(name: String, sfnArn: String, input: String, status: String, taskToken: String = "")

--- a/site-docs/src/main/paradox/index.md
+++ b/site-docs/src/main/paradox/index.md
@@ -13,5 +13,6 @@ This allows any calling code to use any effects which implement these classes, m
 * [SFN Client Usage](sfn/usage/index.md)
 * [SNS Client Usage](sns/usage/index.md)
 * [SQS Client Usage](sqs/usage/index.md)
+* [SSM Client Usage](ssm/usage/index.md)
 
 @@@

--- a/site-docs/src/main/paradox/sfn/usage/fs2.md
+++ b/site-docs/src/main/paradox/sfn/usage/fs2.md
@@ -17,4 +17,8 @@ import io.circe.generic.auto._
   val arn = "arn:aws:states:eu-west-2:123456789:stateMachine:StateMachineName"
   case class Message(value: String)
   val executionResponse = client.startExecution(arn, Message("value"), Option("optionalName"))
+
+  val listStepFunctions = client.listStepFunctions(arn, Status.Running)
+  
+  val sendTaskSuccess = client.sendTaskSuccess("taskToken")
 ```

--- a/site-docs/src/main/paradox/sfn/usage/index.md
+++ b/site-docs/src/main/paradox/sfn/usage/index.md
@@ -3,10 +3,19 @@
 The client exposes one method
 ```scala
 def startExecution[T <: Product](stateMachineArn: String, input: T, name: Option[String] = None)(implicit enc: Encoder[T]): F[StartExecutionResponse]
+
+def listStepFunctions(stepFunctionArn: String, status: Status): F[List[String]]
+
+def sendTaskSuccess(taskToken: String): F[Unit]
+
 ```
 
-This takes a case class and requires an implicit circe encoder to deserialise the case class to JSON.
+The start execution method takes a case class and requires an implicit circe encoder to deserialise the case class to JSON.
 The method will start an execution of the state machine described by the ARN and pass the deserialised json as input.
+
+The list step functions method will return the names of any step functions with the given arn and status.
+
+Send task success returns Unit because the response doesn't contain any useful information. If the task token doesn't exist, an exception will be thrown.
 
 @@@ index
 

--- a/site-docs/src/main/paradox/sfn/usage/zio.md
+++ b/site-docs/src/main/paradox/sfn/usage/zio.md
@@ -19,4 +19,8 @@ import io.circe.generic.auto._ // Used to provide Encoder[T] but you can provide
     val arn = "arn:aws:states:eu-west-2:123456789:stateMachine:StateMachineName"
     case class Message(value: String)
     val executionResponse = client.startExecution(arn, Message("value"), Option("optionalName"))
+
+    val listStepFunctions = client.listStepFunctions(arn, Status.Running)
+    
+    val sendTaskSuccess = client.sendTaskSuccess("taskToken")
 ```

--- a/site-docs/src/main/paradox/ssm/usage/fs2.md
+++ b/site-docs/src/main/paradox/ssm/usage/fs2.md
@@ -1,0 +1,22 @@
+# Use with Cats Effect
+
+## Setup
+
+You will need these dependencies:
+
+@@dependency[sbt,Maven,Gradle] {
+group="uk.gov.nationalarchives" artifact="da-ssm-client_2.13" version=$version$
+}
+
+## Examples
+```scala
+import cats.effect._
+import uk.gov.nationalarchives.DASSMClient
+import io.circe.generic.auto._ // Used to provide Encoder[T]
+
+  case class StoreValue(key: String, value: String)
+  val ssmClient: DASSMClient[IO] = DASSMClient[IO]()
+
+  ssmClient.getParameter[StoreValue]("/test/name")
+  ssmClient.getParameter[StoreValue]("/test/name/encrypted", withDecryption = true)
+```

--- a/site-docs/src/main/paradox/ssm/usage/index.md
+++ b/site-docs/src/main/paradox/ssm/usage/index.md
@@ -1,0 +1,15 @@
+# SSM Client
+
+The client exposes one method
+```scala
+def getParameter[T](parameterName: String, withDecryption: Boolean = false)(using Decoder[T]): F[T]
+```
+
+This method returns the value of the parameter with name `parameterName` as object `T`. `withDecryption` must be true if the parameter is encrypted.
+
+@@@ index
+
+* [Zio](zio.md)
+* [Fs2](fs2.md)
+
+@@@

--- a/site-docs/src/main/paradox/ssm/usage/zio.md
+++ b/site-docs/src/main/paradox/ssm/usage/zio.md
@@ -1,0 +1,23 @@
+# Use with ZIO
+
+## Setup
+You will need these dependencies
+
+@@dependency[sbt,Maven,Gradle] {
+group="uk.gov.nationalarchives" artifact="da-ssm-client_2.13" version=$version$
+group3="dev.zio" artifact3="zio-interop-cats_2.13" version3="23.0.0.5"
+}
+
+## Examples
+```scala
+import uk.gov.nationalarchives.DASSMClient
+import zio.Task
+import zio.interop.catz._
+import io.circe.generic.auto._ // Used to provide Decoder[T]
+
+    case class StoreValue(key: String, value: String)
+    val ssmClient: DASSMClient[Task] = DASSMClient[IO]()
+    
+    ssmClient.getParameter[StoreValue]("/test/name")
+    ssmClient.getParameter[StoreValue]("/test/name/encrypted", withDecryption = true)
+```

--- a/ssm/src/main/scala/uk/gov/nationalarchives/DASSMClient.scala
+++ b/ssm/src/main/scala/uk/gov/nationalarchives/DASSMClient.scala
@@ -1,0 +1,47 @@
+package uk.gov.nationalarchives
+
+import cats.effect.Async
+import cats.implicits.*
+import io.circe.Decoder
+import io.circe.parser.decode
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.ssm.SsmAsyncClient
+import software.amazon.awssdk.services.ssm.model.GetParameterRequest
+
+/** An SSM client. It is written generically so can be used for any effect which has an Async instance. Requires an
+ * implicit instance of cats Async which is used to convert CompletableFuture to F
+ *
+ * @tparam F
+ * Type of the effect
+ */
+trait DASSMClient[F[_]]:
+
+  /**
+   *
+   * @param parameterName
+   *   The name of the SSM parameter
+   * @param withDecryption
+   *   Whether to decrypt the parameter
+   * @tparam T
+   *   The return type of the decoded string
+   * @return
+   *   An object T decoded from the parameter value
+   */
+  def getParameter[T](parameterName: String, withDecryption: Boolean = false)(using Decoder[T]): F[T]
+
+object DASSMClient:
+
+  def apply[F[_]: Async](ssmAsyncClient: SsmAsyncClient): DASSMClient[F] =
+    new DASSMClient[F]:
+      override def getParameter[T](parameterName: String, withDecryption: Boolean)(using enc: Decoder[T]): F[T] =
+        val request = GetParameterRequest.builder.name(parameterName).withDecryption(withDecryption).build
+        Async[F].fromCompletableFuture(Async[F].pure(ssmAsyncClient.getParameter(request))).flatMap { response =>
+          Async[F].fromEither(decode[T](response.parameter().value()))
+        }
+
+  def apply[F[_]: Async](): DASSMClient[F] =
+    lazy val httpClient: SdkAsyncHttpClient = NettyNioAsyncHttpClient.builder.build
+    val ssmAsyncClient = SsmAsyncClient.builder.region(Region.EU_WEST_2).httpClient(httpClient).build
+    DASSMClient[F](ssmAsyncClient)

--- a/ssm/src/test/scala/uk/gov/nationalarchives/DASSMClientTest.scala
+++ b/ssm/src/test/scala/uk/gov/nationalarchives/DASSMClientTest.scala
@@ -1,0 +1,91 @@
+package uk.gov.nationalarchives
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import org.scalatest.flatspec.AnyFlatSpec
+import io.circe.generic.auto.*
+import org.scalatest.matchers.should.Matchers.*
+import software.amazon.awssdk.services.ssm.SsmAsyncClient
+import software.amazon.awssdk.services.ssm.model.{GetParameterRequest, GetParameterResponse, Parameter, ParameterNotFoundException}
+
+import java.util.concurrent.CompletableFuture
+import scala.collection.mutable.ListBuffer
+
+class DASSMClientTest extends AnyFlatSpec:
+  case class Result(value: String)
+
+  case class TestParameter(name: String, encrypted: Boolean, value: String)
+  case class Errors(getParameter: Boolean = false)
+
+  def createClient(initial: ListBuffer[TestParameter], errors: Option[Errors] = None): SsmAsyncClient = new SsmAsyncClient {
+    override def serviceName(): String = "test"
+
+    override def close(): Unit = ()
+
+    override def getParameter(getParameterRequest: GetParameterRequest): CompletableFuture[GetParameterResponse] =
+      if errors.exists(_.getParameter) then throw new Exception("Error getting parameter") else
+      CompletableFuture.completedFuture {
+        initial.find(i => i.name == getParameterRequest.name)
+          .map { parameter =>
+            if parameter.encrypted != getParameterRequest.withDecryption() then
+              throw new Exception("Error decoding encrypted parameter")
+            GetParameterResponse.builder.parameter(Parameter.builder.value(parameter.value).build).build
+          }.getOrElse(throw ParameterNotFoundException.builder.message(s"Parameter ${getParameterRequest.name} not found").build)
+      }
+  }
+
+  "DASSMClient" should "return a decoded unencrypted parameter" in {
+    val ssmAsyncClient = createClient(ListBuffer(TestParameter("testName", false, """{"value": "testValue"}""")))
+
+    val client = DASSMClient[IO](ssmAsyncClient)
+
+    val result = client.getParameter[Result]("testName").unsafeRunSync()
+
+    result.value should equal("testValue")
+  }
+
+  "DASSMClient" should "return a decoded encrypted parameter" in {
+    val ssmAsyncClient = createClient(ListBuffer(TestParameter("testName", true, """{"value": "testValue"}""")))
+
+    val client = DASSMClient[IO](ssmAsyncClient)
+
+    val result = client.getParameter[Result]("testName", withDecryption = true).unsafeRunSync()
+
+    result.value should equal("testValue")
+  }
+
+  "DASSMClient" should "return an error if the parameter is encrypted and withDecryption is false" in {
+    val ssmAsyncClient = createClient(ListBuffer(TestParameter("testName", true, """{"value": "testValue"}""")))
+
+    val client = DASSMClient[IO](ssmAsyncClient)
+
+    val ex = intercept[Exception] {
+      client.getParameter[Result]("testName").unsafeRunSync()
+    }
+
+    ex.getMessage should equal("Error decoding encrypted parameter")
+  }
+
+  "DASSMClient" should "return an error if the parameter is not found" in {
+    val ssmAsyncClient = createClient(ListBuffer(TestParameter("testName", true, """{"value": "testValue"}""")))
+
+    val client = DASSMClient[IO](ssmAsyncClient)
+
+    val ex = intercept[ParameterNotFoundException] {
+      client.getParameter[Result]("invalidTestName").unsafeRunSync()
+    }
+
+    ex.getMessage should equal("Parameter invalidTestName not found")
+  }
+
+  "DASSMClient" should "return an error if there is an error from the SDK" in {
+    val ssmAsyncClient = createClient(ListBuffer[TestParameter](), errors = Option(Errors(getParameter = true)))
+
+    val client = DASSMClient[IO](ssmAsyncClient)
+
+    val ex = intercept[Exception] {
+      client.getParameter[Result]("testName").unsafeRunSync()
+    }
+
+    ex.getMessage should equal("Error getting parameter")
+  }


### PR DESCRIPTION
There are two added to the SFNClient

* List step function executions
* Send task success

There is a new SSMClient with one method

* Get parameter

I've also refactored the SFNClient tests to get rid of Mockito. 