### PR TITLE
Add output param to sendTaskSuccess

### DIFF
--- a/sfn/src/main/scala/uk/gov/nationalarchives/DASFNClient.scala
+++ b/sfn/src/main/scala/uk/gov/nationalarchives/DASFNClient.scala
@@ -46,7 +46,7 @@ trait DASFNClient[F[_]: Async]:
 
   def listStepFunctions(stepFunctionArn: String, status: Status): F[List[String]]
 
-  def sendTaskSuccess(taskToken: String): F[Unit]
+  def sendTaskSuccess[T: Encoder](taskToken: String, potentialOutput: Option[T] = None): F[Unit]
 
 object DASFNClient:
 
@@ -63,9 +63,10 @@ object DASFNClient:
 
   def apply[F[_]: Async](sfnAsyncClient: SfnAsyncClient): DASFNClient[F] = new DASFNClient[F]:
 
-    override def sendTaskSuccess(taskToken: String): F[Unit] = {
+    override def sendTaskSuccess[T: Encoder](taskToken: String, potentialOutput: Option[T] = None): F[Unit] = {
       val sendTaskSuccessRequest = SendTaskSuccessRequest.builder
         .taskToken(taskToken)
+        .output(potentialOutput.map(_.asJson.printWith(Printer.noSpaces)).getOrElse("{}"))
         .build
       sfnAsyncClient.sendTaskSuccess(sendTaskSuccessRequest).liftF.void
     }

--- a/sfn/src/main/scala/uk/gov/nationalarchives/DASFNClient.scala
+++ b/sfn/src/main/scala/uk/gov/nationalarchives/DASFNClient.scala
@@ -66,7 +66,7 @@ object DASFNClient:
     override def sendTaskSuccess[T: Encoder](taskToken: String, potentialOutput: Option[T] = None): F[Unit] = {
       val sendTaskSuccessRequest = SendTaskSuccessRequest.builder
         .taskToken(taskToken)
-        .output(potentialOutput.map(_.asJson.printWith(Printer.noSpaces)).getOrElse("{}"))
+        .output(potentialOutput.map(_.asJson.noSpaces).getOrElse("{}"))
         .build
       sfnAsyncClient.sendTaskSuccess(sendTaskSuccessRequest).liftF.void
     }


### PR DESCRIPTION
This is the output the step will return when sendTaskSuccess is called.
We don't use it as we just pass the input through again but there's an
option to return a different output if we want to.
