### PR TITLE
DR2-2285 Make move arguments optional

### DIFF
--- a/secretsmanager/src/main/scala/uk/gov/nationalarchives/DASecretsManagerClient.scala
+++ b/secretsmanager/src/main/scala/uk/gov/nationalarchives/DASecretsManagerClient.scala
@@ -88,18 +88,18 @@ trait DASecretsManagerClient[F[_]: Async]:
   ): F[PutSecretValueResponse]
 
   /** Update the version stage. This is used to finalise secret rotation.
-    * @param moveToVersionId
-    *   The version you are moving to
-    * @param removeFromVersionId
-    *   The version you are moving from
+    * @param potentialMoveToVersionId
+    *   The optional version you are moving to
+    * @param potentialRemoveFromVersionId
+    *   The optional version you are moving from
     * @param stage
     *   The stage of the version
     * @return
     *   UpdateSecretVersionStageResponse wrapped in F[_]
     */
   def updateSecretVersionStage(
-      moveToVersionId: Option[String],
-      removeFromVersionId: Option[String],
+      potentialMoveToVersionId: Option[String],
+      potentialRemoveFromVersionId: Option[String],
       stage: Stage = Current
   ): F[UpdateSecretVersionStageResponse]
 
@@ -157,16 +157,16 @@ object DASecretsManagerClient:
         secretsManagerAsyncClient.putSecretValue(request).liftF
 
       override def updateSecretVersionStage(
-          moveToVersionId: Option[String],
-          removeFromVersionId: Option[String],
+          potentialMoveToVersionId: Option[String],
+          potentialRemoveFromVersionId: Option[String],
           stage: Stage = Current
       ): F[UpdateSecretVersionStageResponse] =
         val request = UpdateSecretVersionStageRequest
           .builder()
           .secretId(secretId)
           .versionStage(stage.toString)
-          .moveToVersionId(moveToVersionId.orNull)
-          .removeFromVersionId(removeFromVersionId.orNull)
+          .moveToVersionId(potentialMoveToVersionId.orNull)
+          .removeFromVersionId(potentialRemoveFromVersionId.orNull)
           .build
         secretsManagerAsyncClient.updateSecretVersionStage(request).liftF
 

--- a/secretsmanager/src/main/scala/uk/gov/nationalarchives/DASecretsManagerClient.scala
+++ b/secretsmanager/src/main/scala/uk/gov/nationalarchives/DASecretsManagerClient.scala
@@ -98,8 +98,8 @@ trait DASecretsManagerClient[F[_]: Async]:
     *   UpdateSecretVersionStageResponse wrapped in F[_]
     */
   def updateSecretVersionStage(
-      moveToVersionId: String,
-      removeFromVersionId: String,
+      moveToVersionId: Option[String],
+      removeFromVersionId: Option[String],
       stage: Stage = Current
   ): F[UpdateSecretVersionStageResponse]
 
@@ -157,16 +157,16 @@ object DASecretsManagerClient:
         secretsManagerAsyncClient.putSecretValue(request).liftF
 
       override def updateSecretVersionStage(
-          moveToVersionId: String,
-          removeFromVersionId: String,
+          moveToVersionId: Option[String],
+          removeFromVersionId: Option[String],
           stage: Stage = Current
       ): F[UpdateSecretVersionStageResponse] =
         val request = UpdateSecretVersionStageRequest
           .builder()
           .secretId(secretId)
           .versionStage(stage.toString)
-          .moveToVersionId(moveToVersionId)
-          .removeFromVersionId(removeFromVersionId)
+          .moveToVersionId(moveToVersionId.orNull)
+          .removeFromVersionId(removeFromVersionId.orNull)
           .build
         secretsManagerAsyncClient.updateSecretVersionStage(request).liftF
 

--- a/secretsmanager/src/test/scala/uk/gov/nationalarchives/DASecretsManagerClientTest.scala
+++ b/secretsmanager/src/test/scala/uk/gov/nationalarchives/DASecretsManagerClientTest.scala
@@ -248,7 +248,7 @@ class DASecretsManagerClientTest extends AnyFlatSpec with MockitoSugar with Befo
     ex.getMessage should equal("Error from client")
   }
 
-  "updateSecretVersionStage" should "not pass move from version if it is not defined" in {
+  "updateSecretVersionStage" should "not pass move to version if it is not defined" in {
     val updateSecretVersionStageCaptor = ArgumentCaptor.forClass(classOf[UpdateSecretVersionStageRequest])
     when(secretsManagerAsyncClient.updateSecretVersionStage(updateSecretVersionStageCaptor.capture()))
       .thenReturn(CompletableFuture.completedFuture(UpdateSecretVersionStageResponse.builder.build))
@@ -257,7 +257,7 @@ class DASecretsManagerClientTest extends AnyFlatSpec with MockitoSugar with Befo
     updateSecretVersionStageCaptor.getValue.moveToVersionId() should equal(null)
   }
 
-  "updateSecretVersionStage" should "not pass move to version if it is not defined" in {
+  "updateSecretVersionStage" should "not pass remove from version if it is not defined" in {
     val updateSecretVersionStageCaptor = ArgumentCaptor.forClass(classOf[UpdateSecretVersionStageRequest])
     when(secretsManagerAsyncClient.updateSecretVersionStage(updateSecretVersionStageCaptor.capture()))
       .thenReturn(CompletableFuture.completedFuture(UpdateSecretVersionStageResponse.builder.build))

--- a/site-docs/src/main/paradox/secretsmanager/usage/fs2.md
+++ b/site-docs/src/main/paradox/secretsmanager/usage/fs2.md
@@ -35,7 +35,9 @@ object Examples {
   val putSecretValueWithStage: IO[PutSecretValueResponse] = client.putSecretValue(SecretRequest("username", "password"), Pending)
   val putSecretValueWithStageAndToken: IO[PutSecretValueResponse] = client.putSecretValue(SecretRequest("username", "password"), Pending, Option("clientRequestToken"))
 
-  val updateSecretVersion: IO[UpdateSecretVersionStageResponse] = client.updateSecretVersionStage("moveToVersion", "removeFromVersion")
-  val updateSecretVersionWithStage: IO[UpdateSecretVersionStageResponse] = client.updateSecretVersionStage("moveToVersion", "removeFromVersion", Pending)
+  val updateSecretVersion: IO[UpdateSecretVersionStageResponse] = client.updateSecretVersionStage(Option("moveToVersion"), Option("removeFromVersion"))
+  val updateSecretVersionWithStage: IO[UpdateSecretVersionStageResponse] = client.updateSecretVersionStage(Option("moveToVersion"), Option("removeFromVersion"), Pending)
+  val updateSecretVersionNoMoveTo: IO[UpdateSecretVersionStageResponse] = client.updateSecretVersionStage(None, Option("removeFromVersion"), Pending)
+  val updateSecretVersionNoRemoveFrom: IO[UpdateSecretVersionStageResponse] = client.updateSecretVersionStage(Option("moveToVersion"), None, Pending)
 }
 ```

--- a/site-docs/src/main/paradox/secretsmanager/usage/index.md
+++ b/site-docs/src/main/paradox/secretsmanager/usage/index.md
@@ -7,7 +7,7 @@ def describeSecret(): F[DescribeSecretResponse]
 def getSecretValue[T](stage: Stage = Current)(implicit decoder: Decoder[T]): F[T]
 def getSecretValue[T](versionId: String, stage: Stage)(implicit decoder: Decoder[T]): F[T]
 def putSecretValue[T](secret: T, stage: Stage = Current, clientRequestToken: Option[String] = None)(implicit encoder: Encoder[T]): F[PutSecretValueResponse]
-def updateSecretVersionStage(moveToVersionId: String, removeFromVersionId: String, stage: Stage = Current): F[UpdateSecretVersionStageResponse]
+def updateSecretVersionStage(potentialMoveToVersionId: Option[String], potentialRemoveFromVersionId: Option[String], stage: Stage = Current): F[UpdateSecretVersionStageResponse]
 ```
 
 @@@ index

--- a/site-docs/src/main/paradox/secretsmanager/usage/zio.md
+++ b/site-docs/src/main/paradox/secretsmanager/usage/zio.md
@@ -36,7 +36,9 @@ object Examples {
   val putSecretValueWithStage: Task[PutSecretValueResponse] = client.putSecretValue(SecretRequest("username", "password"), Pending)
   val putSecretValueWithStageAndToken: Task[PutSecretValueResponse] = client.putSecretValue(SecretRequest("username", "password"), Pending, Option("clientRequestToken"))
 
-  val updateSecretVersion: Task[UpdateSecretVersionStageResponse] = client.updateSecretVersionStage("moveToVersion", "removeFromVersion")
-  val updateSecretVersionWithStage: Task[UpdateSecretVersionStageResponse] = client.updateSecretVersionStage("moveToVersion", "removeFromVersion", Pending)
+  val updateSecretVersion: Task[UpdateSecretVersionStageResponse] = client.updateSecretVersionStage(Option("moveToVersion"), Option("removeFromVersion"))
+  val updateSecretVersionWithStage: Task[UpdateSecretVersionStageResponse] = client.updateSecretVersionStage(Option("moveToVersion"), Option("removeFromVersion"), Pending)
+  val updateSecretVersionNoMoveTo: Task[UpdateSecretVersionStageResponse] = client.updateSecretVersionStage(None, Option("removeFromVersion"), Pending)
+  val updateSecretVersionNoRemoveFrom: Task[UpdateSecretVersionStageResponse] = client.updateSecretVersionStage(Option("moveToVersion"), None, Pending)
 }
 ```


### PR DESCRIPTION
The remove from and move to arguments are optional in the
UpdateSecretVersionStageRequest anyway and we need to pass in null for
moveToVersionId if the setting secret in Preservica fails. This should
allow us to.
