### PR TITLE
DR2-2772 Only set expressionAttributeNames if necessary

### DIFF
--- a/dynamodb/src/main/scala/uk/gov/nationalarchives/DADynamoDBClient.scala
+++ b/dynamodb/src/main/scala/uk/gov/nationalarchives/DADynamoDBClient.scala
@@ -231,11 +231,6 @@ object DADynamoDBClient:
               .map(attr => if reservedWords.contains(attr) then s"#${attr.dropRight(1)} = :$attr" else s"$attr = :$attr")
               .mkString(", ")}"
 
-        val expressionAttributeNames = toUpdate.keySet
-          .find(reservedWords.contains)
-          .map(r => Map(s"#${r.dropRight(1)}" -> r))
-          .getOrElse(Map())
-
         val expressionAttributeValues: Map[String, AttributeValue] =
           toUpdate.map { case (name, value) => s":$name" -> value }
 
@@ -245,11 +240,16 @@ object DADynamoDBClient:
           .key(dynamoDbRequest.primaryKeyAndItsValue.asJava)
           .updateExpression(updateExpression)
           .expressionAttributeValues(expressionAttributeValues.asJava)
-          .expressionAttributeNames(expressionAttributeNames.asJava)
+
+        val builderWithExpressionNames = toUpdate.keySet
+          .find(reservedWords.contains)
+          .map(r => Map(s"#${r.dropRight(1)}" -> r).asJava)
+          .map(updateAttributeValueRequestBuilder.expressionAttributeNames)
+          .getOrElse(updateAttributeValueRequestBuilder)
 
         val updateAttributeValueRequest = dynamoDbRequest.conditionalExpression
-          .map(updateAttributeValueRequestBuilder.conditionExpression)
-          .getOrElse(updateAttributeValueRequestBuilder)
+          .map(builderWithExpressionNames.conditionExpression)
+          .getOrElse(builderWithExpressionNames)
           .build
 
         dynamoDBClient


### PR DESCRIPTION
If you pass in an empty map to this parameter, you get an error.

This should only set it if there is something to set.

I tried adding a test but the builder sets an empty map in the final
object so it's impossible to tell the difference between the old code
and the new.
