### PR TITLE
Stop creating the client twice.

### DIFF
--- a/s3/src/main/scala/uk/gov/nationalarchives/DAS3Client.scala
+++ b/s3/src/main/scala/uk/gov/nationalarchives/DAS3Client.scala
@@ -145,7 +145,7 @@ object DAS3Client:
     .minimumPartSizeInBytes(10 * 1024 * 1024)
     .build()
 
-  private def transferManager(asyncClient: S3AsyncClient = asyncClient()): S3TransferManager = S3TransferManager
+  private def transferManager(asyncClient: S3AsyncClient): S3TransferManager = S3TransferManager
     .builder()
     .s3Client(asyncClient)
     .build()
@@ -171,9 +171,14 @@ object DAS3Client:
     DAS3Client(transferManager(asyncClient), asyncClient)
   }
 
+  def apply[F[_]: Async](): DAS3Client[F] = {
+    val client = asyncClient()
+    DAS3Client(transferManager(client), client)
+  }
+
   def apply[F[_]: Async](
-      transferManager: S3TransferManager = transferManager(),
-      asyncClient: S3AsyncClient = asyncClient()
+      transferManager: S3TransferManager,
+      asyncClient: S3AsyncClient
   ): DAS3Client[F] =
     new DAS3Client[F] {
 


### PR DESCRIPTION
The `apply()` method had two default arguments and `transferManager()`
had a default argument which created an `asyncClient` so two asyncClients were
being created every time the apply method was called. This is an expensive operation
and should only be done once.
